### PR TITLE
🧹 Refactor node cleanup into test helper

### DIFF
--- a/node/tests/helper_test.go
+++ b/node/tests/helper_test.go
@@ -1,0 +1,16 @@
+package node_test
+
+import (
+	"testing"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func cleanupNodes[T node.Node](t *testing.T, nodes []T) {
+	t.Helper()
+	for i := 0; i < len(nodes); i++ {
+		if err := nodes[i].Delete(); err != nil {
+			t.Fatalf("Node %d: Delete() error = %v", i, err)
+		}
+	}
+}

--- a/node/tests/helper_test.go
+++ b/node/tests/helper_test.go
@@ -2,13 +2,15 @@ package node_test
 
 import (
 	"testing"
-
-	"github.com/lhemerly/Constellation/node"
 )
 
-func cleanupNodes[T node.Node](t *testing.T, nodes []T) {
+type deletableNode interface {
+	Delete() error
+}
+
+func cleanupNodes[T deletableNode](t *testing.T, nodes []T) {
 	t.Helper()
-	for i := 0; i < len(nodes); i++ {
+	for i := range nodes {
 		if err := nodes[i].Delete(); err != nil {
 			t.Fatalf("Node %d: Delete() error = %v", i, err)
 		}

--- a/node/tests/node_event_notification_test.go
+++ b/node/tests/node_event_notification_test.go
@@ -75,9 +75,5 @@ func TestBaseNodeEventNotification(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < numNodes; i++ {
-		if err := nodes[i].Delete(); err != nil {
-			t.Fatalf("Node %d: Delete() error = %v", i, err)
-		}
-	}
+	cleanupNodes(t, nodes)
 }

--- a/node/tests/node_processing_test.go
+++ b/node/tests/node_processing_test.go
@@ -42,9 +42,5 @@ func TestBaseNodeDataProcessing(t *testing.T) {
 
 	wg.Wait()
 
-	for i := 0; i < numNodes; i++ {
-		if err := nodes[i].Delete(); err != nil {
-			t.Fatalf("Node %d: Delete() error = %v", i, err)
-		}
-	}
+	cleanupNodes(t, nodes)
 }

--- a/node/tests/node_subscription_management_test.go
+++ b/node/tests/node_subscription_management_test.go
@@ -77,9 +77,5 @@ func TestBaseNodeSubscriptionManagement(t *testing.T) {
         }
     }
 
-    for i := 0; i < numNodes; i++ {
-        if err := nodes[i].Delete(); err != nil {
-            t.Fatalf("Node %d: Delete() error = %v", i, err)
-        }
-    }
+    cleanupNodes(t, nodes)
 }

--- a/node/tests/node_subscription_management_test.go
+++ b/node/tests/node_subscription_management_test.go
@@ -1,81 +1,81 @@
 package node_test
 
 import (
-    "sync"
-    "testing"
 	"fmt"
+	"sync"
+	"testing"
 
-    "github.com/lhemerly/Constellation/node"
+	"github.com/lhemerly/Constellation/node"
 )
 
 func TestBaseNodeSubscriptionManagement(t *testing.T) {
-    const numNodes = 100
-    var wg sync.WaitGroup
+	const numNodes = 100
+	var wg sync.WaitGroup
 
-    nodes := make([]*node.BaseNode, numNodes)
-    for i := 0; i < numNodes; i++ {
-        node := node.NewBaseNode("node-" + fmt.Sprint(i))
-        nodes[i] = node
-        if err := node.Create(); err != nil {
-            t.Fatalf("Node %d: Create() error = %v", i, err)
-        }
-    }
+	nodes := make([]*node.BaseNode, numNodes)
+	for i := 0; i < numNodes; i++ {
+		node := node.NewBaseNode("node-" + fmt.Sprint(i))
+		nodes[i] = node
+		if err := node.Create(); err != nil {
+			t.Fatalf("Node %d: Create() error = %v", i, err)
+		}
+	}
 
-    // Test subscription management
-    for i := 0; i < numNodes; i++ {
-        for j := 0; j < numNodes; j++ {
-            if i != j {
-                wg.Add(1)
-                go func(i, j int) {
-                    defer wg.Done()
-                    if err := nodes[i].Subscribe(nodes[j]); err != nil {
-                        t.Errorf("Node %d: Subscribe() error = %v", i, err)
-                    }
-                }(i, j)
-            }
-        }
-    }
+	// Test subscription management
+	for i := 0; i < numNodes; i++ {
+		for j := 0; j < numNodes; j++ {
+			if i != j {
+				wg.Add(1)
+				go func(i, j int) {
+					defer wg.Done()
+					if err := nodes[i].Subscribe(nodes[j]); err != nil {
+						t.Errorf("Node %d: Subscribe() error = %v", i, err)
+					}
+				}(i, j)
+			}
+		}
+	}
 
-    wg.Wait()
+	wg.Wait()
 
-    // Verify subscriptions
-    for i := 0; i < numNodes; i++ {
-        for j := 0; j < numNodes; j++ {
-            if i != j {
-                if nodes[i].GetSubscription(nodes[j].GetID()) == nil {
-                    t.Errorf("Node %d: Subscription to node %d not found", i, j)
-                }
-            }
-        }
-    }
+	// Verify subscriptions
+	for i := 0; i < numNodes; i++ {
+		for j := 0; j < numNodes; j++ {
+			if i != j {
+				if nodes[i].GetSubscription(nodes[j].GetID()) == nil {
+					t.Errorf("Node %d: Subscription to node %d not found", i, j)
+				}
+			}
+		}
+	}
 
-    // Test unsubscription management
-    for i := 0; i < numNodes; i++ {
-        for j := 0; j < numNodes; j++ {
-            if i != j {
-                wg.Add(1)
-                go func(i, j int) {
-                    defer wg.Done()
-                    if err := nodes[i].Unsubscribe(nodes[j]); err != nil {
-                        t.Errorf("Node %d: Unsubscribe() error = %v", i, err)
-                    }
-                }(i, j)
-            }
-        }
-    }
+	// Test unsubscription management
+	for i := 0; i < numNodes; i++ {
+		for j := 0; j < numNodes; j++ {
+			if i != j {
+				wg.Add(1)
+				go func(i, j int) {
+					defer wg.Done()
+					if err := nodes[i].Unsubscribe(nodes[j]); err != nil {
+						t.Errorf("Node %d: Unsubscribe() error = %v", i, err)
+					}
+				}(i, j)
+			}
+		}
+	}
 
-    wg.Wait()
+	wg.Wait()
 
-    // Verify unsubscriptions
-    for i := 0; i < numNodes; i++ {
-        for j := 0; j < numNodes; j++ {
-            if i != j {
-                if nodes[i].GetSubscription(nodes[j].GetID()) != nil {
-                    t.Errorf("Node %d: Subscription to node %d still exists", i, j)
-                }
-            }
-        }
-    }
+	// Verify unsubscriptions
+	for i := 0; i < numNodes; i++ {
+		for j := 0; j < numNodes; j++ {
+			if i != j {
+				if nodes[i].GetSubscription(nodes[j].GetID()) != nil {
+					t.Errorf("Node %d: Subscription to node %d still exists", i, j)
+				}
+			}
+		}
+	}
 
-    cleanupNodes(t, nodes)
+	cleanupNodes(t, nodes)
 }

--- a/node/tests/node_unique_id_test.go
+++ b/node/tests/node_unique_id_test.go
@@ -30,8 +30,7 @@ func TestBaseNodeUniqueIdentification(t *testing.T) {
 		if nodes[i].GetID() != "node-"+fmt.Sprint(i) {
 			t.Errorf("Node %d: GetID() = %v, want %v", i, nodes[i].GetID(), "node-"+fmt.Sprint(i))
 		}
-		if err := nodes[i].Delete(); err != nil {
-			t.Fatalf("Node %d: Delete() error = %v", i, err)
-		}
 	}
+
+	cleanupNodes(t, nodes)
 }


### PR DESCRIPTION
🎯 **What:** Extracted the repeated node cleanup loop into a generic test helper `cleanupNodes` in `node/tests/helper_test.go`. Replaced duplicated cleanup loops in multiple test files with calls to the new helper.

💡 **Why:** To reduce code duplication and improve the maintainability and readability of the test suite. The helper function utilizes `t.Helper()` so that any test failures are correctly attributed to the calling test line.

✅ **Verification:** Ran the full test suite (`go test ./node/tests/`) to ensure no functionality is broken and all tests pass successfully.

✨ **Result:** Improved code health and simplified test cleanup across the `node/tests` package.

---
*PR created automatically by Jules for task [1652256739011301866](https://jules.google.com/task/1652256739011301866) started by @lhemerly*