### PR TITLE
ci: Update GitHub Actions to avoid deprecated actions/cache package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,10 +38,10 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.out
+          files: coverage.out
           fail_ci_if_error: false
 
   build:


### PR DESCRIPTION
This PR updates the codecov-action dependency in the CI workflows to version 5. Codecov-action v4 uses an outdated version of the `@actions/cache` package internally, which is subject to upcoming GitHub Actions deprecations and brownouts starting February 1st, 2025. 

Additionally, updated the deprecated parameter `file` to `files` as per codecov v5 action inputs. All other actions in the workflow are fully up-to-date.

---
*PR created automatically by Jules for task [5256210723690267158](https://jules.google.com/task/5256210723690267158) started by @lhemerly*