### PR TITLE
feat: Add load balancer, pipeline, failover nodes and common middlewares

### DIFF
--- a/node/failover_node.go
+++ b/node/failover_node.go
@@ -1,0 +1,76 @@
+package node
+
+import (
+	"errors"
+	"sync"
+)
+
+// ErrNoNodesFailover is returned when both primary and fallback nodes are missing.
+var ErrNoNodesFailover = errors.New("no primary or fallback nodes configured")
+
+// ErrFailoverFailed is returned when both primary and fallback processing fail.
+var ErrFailoverFailed = errors.New("failover completely failed")
+
+// FailoverNode extends BaseNode to provide fault tolerance by trying a secondary node if the primary fails.
+type FailoverNode struct {
+	*BaseNode
+	nodesMutex sync.RWMutex
+	primary    Node
+	fallback   Node
+}
+
+// NewFailoverNode creates a new FailoverNode with the given ID.
+func NewFailoverNode(id string) *FailoverNode {
+	f := &FailoverNode{
+		BaseNode: NewBaseNode(id),
+	}
+
+	f.SetProcessFunc(f.processFailover)
+	return f
+}
+
+// SetPrimary sets the primary node.
+func (f *FailoverNode) SetPrimary(node Node) {
+	f.nodesMutex.Lock()
+	defer f.nodesMutex.Unlock()
+	f.primary = node
+}
+
+// SetFallback sets the secondary/fallback node.
+func (f *FailoverNode) SetFallback(node Node) {
+	f.nodesMutex.Lock()
+	defer f.nodesMutex.Unlock()
+	f.fallback = node
+}
+
+// processFailover attempts to process using primary, then fallback on error.
+func (f *FailoverNode) processFailover(input []byte) ([]byte, error) {
+	f.nodesMutex.RLock()
+	primaryNode := f.primary
+	fallbackNode := f.fallback
+	f.nodesMutex.RUnlock()
+
+	if primaryNode == nil && fallbackNode == nil {
+		return nil, ErrNoNodesFailover
+	}
+
+	var primaryErr error
+	if primaryNode != nil {
+		res, err := primaryNode.Process(input)
+		if err == nil {
+			return res, nil
+		}
+		primaryErr = err
+	}
+
+	if fallbackNode != nil {
+		res, err := fallbackNode.Process(input)
+		if err == nil {
+			return res, nil
+		}
+		// Return wrapped error or just failover error, we can combine them.
+		return nil, errors.Join(ErrFailoverFailed, primaryErr, err)
+	}
+
+	return nil, errors.Join(ErrFailoverFailed, primaryErr)
+}

--- a/node/failover_node.go
+++ b/node/failover_node.go
@@ -56,7 +56,11 @@ func (f *FailoverNode) processFailover(input []byte) ([]byte, error) {
 
 	var primaryErr error
 	if primaryNode != nil {
-		res, err := primaryNode.Process(input)
+		// Clone input to prevent in-place modification by the primary node before fallback
+		inputCopy := make([]byte, len(input))
+		copy(inputCopy, input)
+
+		res, err := primaryNode.Process(inputCopy)
 		if err == nil {
 			return res, nil
 		}
@@ -64,6 +68,7 @@ func (f *FailoverNode) processFailover(input []byte) ([]byte, error) {
 	}
 
 	if fallbackNode != nil {
+		// We can safely use the original input buffer for the final fallback attempt
 		res, err := fallbackNode.Process(input)
 		if err == nil {
 			return res, nil

--- a/node/load_balancer_node.go
+++ b/node/load_balancer_node.go
@@ -1,0 +1,84 @@
+package node
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+)
+
+// ErrNoNodes is returned when the LoadBalancerNode has no destinations.
+var ErrNoNodes = errors.New("no destination nodes available")
+
+// LoadBalancerNode extends BaseNode to distribute incoming requests across
+// multiple destination nodes using a round-robin strategy.
+type LoadBalancerNode struct {
+	*BaseNode
+	nodesMutex sync.RWMutex
+	nodes      []Node
+	counter    uint64
+}
+
+// NewLoadBalancerNode creates a new LoadBalancerNode with the given ID.
+func NewLoadBalancerNode(id string) *LoadBalancerNode {
+	lb := &LoadBalancerNode{
+		BaseNode: NewBaseNode(id),
+		nodes:    make([]Node, 0),
+	}
+
+	// Set the processing function to load balance requests
+	lb.SetProcessFunc(lb.loadBalance)
+	return lb
+}
+
+// AddNode adds a destination node to the load balancer pool.
+func (lb *LoadBalancerNode) AddNode(node Node) {
+	lb.nodesMutex.Lock()
+	defer lb.nodesMutex.Unlock()
+	lb.nodes = append(lb.nodes, node)
+}
+
+// RemoveNode removes a destination node from the load balancer pool by its ID.
+func (lb *LoadBalancerNode) RemoveNode(nodeID string) {
+	lb.nodesMutex.Lock()
+	defer lb.nodesMutex.Unlock()
+
+	for i, node := range lb.nodes {
+		if node.GetID() == nodeID {
+			// Remove the node while preserving order or unordered is fine too.
+			// Fast removal since order doesn't strictly matter for round-robin,
+			// but we'll preserve order for predictability.
+			lb.nodes = append(lb.nodes[:i], lb.nodes[i+1:]...)
+			break
+		}
+	}
+}
+
+// GetNodes returns the current list of destination nodes.
+func (lb *LoadBalancerNode) GetNodes() []Node {
+	lb.nodesMutex.RLock()
+	defer lb.nodesMutex.RUnlock()
+
+	// Return a copy to avoid external modifications
+	nodesCopy := make([]Node, len(lb.nodes))
+	copy(nodesCopy, lb.nodes)
+	return nodesCopy
+}
+
+// loadBalance distributes the input data to the next available node using round-robin.
+func (lb *LoadBalancerNode) loadBalance(input []byte) ([]byte, error) {
+	lb.nodesMutex.RLock()
+	nodesCount := uint64(len(lb.nodes))
+
+	if nodesCount == 0 {
+		lb.nodesMutex.RUnlock()
+		return nil, ErrNoNodes
+	}
+
+	// Atomically get the current counter, then increment it
+	current := atomic.AddUint64(&lb.counter, 1) - 1
+	idx := current % nodesCount
+	targetNode := lb.nodes[idx]
+	lb.nodesMutex.RUnlock()
+
+	return targetNode.Process(input)
+}

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -33,7 +33,12 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			var output []byte
 
 			for i := 0; i <= retries; i++ {
-				output, err = next(input)
+				// Clone the input buffer for each attempt to avoid side effects
+				// from in-place modifications during a failed process attempt.
+				inputCopy := make([]byte, len(input))
+				copy(inputCopy, input)
+
+				output, err = next(inputCopy)
 				if err == nil {
 					return output, nil
 				}

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -1,0 +1,69 @@
+package node
+
+import (
+	"errors"
+	"log"
+	"time"
+)
+
+// LoggingMiddleware logs the payload size and processing time.
+func LoggingMiddleware(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+	return func(input []byte) ([]byte, error) {
+		start := time.Now()
+		log.Printf("Process started. Input size: %d bytes\n", len(input))
+
+		output, err := next(input)
+
+		duration := time.Since(start)
+		if err != nil {
+			log.Printf("Process failed after %s: %v\n", duration, err)
+		} else {
+			log.Printf("Process completed in %s. Output size: %d bytes\n", duration, len(output))
+		}
+
+		return output, err
+	}
+}
+
+// RetryMiddleware retries a failed operation for a specified number of times with a delay.
+func RetryMiddleware(retries int, delay time.Duration) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			var err error
+			var output []byte
+
+			for i := 0; i <= retries; i++ {
+				output, err = next(input)
+				if err == nil {
+					return output, nil
+				}
+
+				if i < retries {
+					time.Sleep(delay)
+				}
+			}
+
+			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RecoveryMiddleware recovers from panics gracefully and turns them into errors.
+func RecoveryMiddleware(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+	return func(input []byte) (output []byte, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				switch x := r.(type) {
+				case string:
+					err = errors.New(x)
+				case error:
+					err = x
+				default:
+					err = errors.New("unknown panic occurred")
+				}
+			}
+		}()
+
+		return next(input)
+	}
+}

--- a/node/pipeline_node.go
+++ b/node/pipeline_node.go
@@ -1,0 +1,71 @@
+package node
+
+import (
+	"errors"
+	"sync"
+)
+
+// ErrEmptyPipeline is returned when the PipelineNode has no stages.
+var ErrEmptyPipeline = errors.New("empty pipeline")
+
+// PipelineNode extends BaseNode to process data sequentially through multiple chained nodes.
+type PipelineNode struct {
+	*BaseNode
+	stagesMutex sync.RWMutex
+	stages      []Node
+}
+
+// NewPipelineNode creates a new PipelineNode with the given ID.
+func NewPipelineNode(id string) *PipelineNode {
+	p := &PipelineNode{
+		BaseNode: NewBaseNode(id),
+		stages:   make([]Node, 0),
+	}
+
+	p.SetProcessFunc(p.processPipeline)
+	return p
+}
+
+// AddStage appends a node to the pipeline sequence.
+func (p *PipelineNode) AddStage(node Node) {
+	p.stagesMutex.Lock()
+	defer p.stagesMutex.Unlock()
+	p.stages = append(p.stages, node)
+}
+
+// GetStages returns the nodes composing the pipeline.
+func (p *PipelineNode) GetStages() []Node {
+	p.stagesMutex.RLock()
+	defer p.stagesMutex.RUnlock()
+
+	stagesCopy := make([]Node, len(p.stages))
+	copy(stagesCopy, p.stages)
+	return stagesCopy
+}
+
+// processPipeline sequentially passes the input through all registered stages.
+// The output of one stage becomes the input of the next.
+func (p *PipelineNode) processPipeline(input []byte) ([]byte, error) {
+	p.stagesMutex.RLock()
+
+	if len(p.stages) == 0 {
+		p.stagesMutex.RUnlock()
+		return nil, ErrEmptyPipeline
+	}
+
+	stagesCopy := make([]Node, len(p.stages))
+	copy(stagesCopy, p.stages)
+	p.stagesMutex.RUnlock()
+
+	currentData := input
+	var err error
+
+	for _, stage := range stagesCopy {
+		currentData, err = stage.Process(currentData)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return currentData, nil
+}

--- a/node/tests/failover_test.go
+++ b/node/tests/failover_test.go
@@ -1,0 +1,108 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"testing"
+)
+
+func TestFailoverNode_PrimarySuccess(t *testing.T) {
+	f := node.NewFailoverNode("failover-1")
+	primary := node.NewBaseNode("primary")
+	fallback := node.NewBaseNode("fallback")
+
+	var nodes []node.Node
+	nodes = append(nodes, f, primary, fallback)
+	defer cleanupNodes(t, nodes)
+
+	primary.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("primary-success"), nil
+	})
+	fallback.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("fallback-success"), nil
+	})
+
+	f.SetPrimary(primary)
+	f.SetFallback(fallback)
+
+	res, err := f.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(res) != "primary-success" {
+		t.Errorf("expected primary-success, got %s", string(res))
+	}
+}
+
+func TestFailoverNode_FallbackSuccess(t *testing.T) {
+	f := node.NewFailoverNode("failover-2")
+	primary := node.NewBaseNode("primary")
+	fallback := node.NewBaseNode("fallback")
+
+	var nodes []node.Node
+	nodes = append(nodes, f, primary, fallback)
+	defer cleanupNodes(t, nodes)
+
+	primaryErr := errors.New("primary failed")
+	primary.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, primaryErr
+	})
+	fallback.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("fallback-success"), nil
+	})
+
+	f.SetPrimary(primary)
+	f.SetFallback(fallback)
+
+	res, err := f.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(res) != "fallback-success" {
+		t.Errorf("expected fallback-success, got %s", string(res))
+	}
+}
+
+func TestFailoverNode_BothFail(t *testing.T) {
+	f := node.NewFailoverNode("failover-3")
+	primary := node.NewBaseNode("primary")
+	fallback := node.NewBaseNode("fallback")
+
+	var nodes []node.Node
+	nodes = append(nodes, f, primary, fallback)
+	defer cleanupNodes(t, nodes)
+
+	primaryErr := errors.New("primary failed")
+	fallbackErr := errors.New("fallback failed")
+
+	primary.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, primaryErr
+	})
+	fallback.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, fallbackErr
+	})
+
+	f.SetPrimary(primary)
+	f.SetFallback(fallback)
+
+	_, err := f.Process([]byte("input"))
+	if !errors.Is(err, node.ErrFailoverFailed) {
+		t.Errorf("expected ErrFailoverFailed, got %v", err)
+	}
+	if !errors.Is(err, primaryErr) {
+		t.Errorf("expected error to wrap primary error")
+	}
+	if !errors.Is(err, fallbackErr) {
+		t.Errorf("expected error to wrap fallback error")
+	}
+}
+
+func TestFailoverNode_NoNodes(t *testing.T) {
+	f := node.NewFailoverNode("failover-empty")
+	defer cleanupNodes(t, []node.Node{f})
+
+	_, err := f.Process([]byte("input"))
+	if !errors.Is(err, node.ErrNoNodesFailover) {
+		t.Errorf("expected ErrNoNodesFailover, got %v", err)
+	}
+}

--- a/node/tests/load_balancer_test.go
+++ b/node/tests/load_balancer_test.go
@@ -1,0 +1,71 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"testing"
+)
+
+func TestLoadBalancerNode_RoundRobin(t *testing.T) {
+	lb := node.NewLoadBalancerNode("lb-1")
+	node1 := node.NewBaseNode("dest-1")
+	node2 := node.NewBaseNode("dest-2")
+	node3 := node.NewBaseNode("dest-3")
+
+	var nodes []node.Node
+	nodes = append(nodes, lb, node1, node2, node3)
+	defer cleanupNodes(t, nodes)
+
+	// Custom process func to identify which node processed the request
+	node1.SetProcessFunc(func(input []byte) ([]byte, error) { return []byte("node1"), nil })
+	node2.SetProcessFunc(func(input []byte) ([]byte, error) { return []byte("node2"), nil })
+	node3.SetProcessFunc(func(input []byte) ([]byte, error) { return []byte("node3"), nil })
+
+	lb.AddNode(node1)
+	lb.AddNode(node2)
+	lb.AddNode(node3)
+
+	expectedOrder := []string{"node1", "node2", "node3", "node1", "node2"}
+
+	for i, expected := range expectedOrder {
+		res, err := lb.Process([]byte("input"))
+		if err != nil {
+			t.Fatalf("Step %d: unexpected error %v", i, err)
+		}
+		if string(res) != expected {
+			t.Errorf("Step %d: expected %s, got %s", i, expected, string(res))
+		}
+	}
+}
+
+func TestLoadBalancerNode_Empty(t *testing.T) {
+	lb := node.NewLoadBalancerNode("lb-empty")
+	defer cleanupNodes(t, []node.Node{lb})
+
+	_, err := lb.Process([]byte("input"))
+	if !errors.Is(err, node.ErrNoNodes) {
+		t.Errorf("expected ErrNoNodes, got %v", err)
+	}
+}
+
+func TestLoadBalancerNode_RemoveNode(t *testing.T) {
+	lb := node.NewLoadBalancerNode("lb-rm")
+	node1 := node.NewBaseNode("dest-1")
+	node2 := node.NewBaseNode("dest-2")
+
+	var nodes []node.Node
+	nodes = append(nodes, lb, node1, node2)
+	defer cleanupNodes(t, nodes)
+
+	lb.AddNode(node1)
+	lb.AddNode(node2)
+
+	lb.RemoveNode("dest-1")
+
+	if len(lb.GetNodes()) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(lb.GetNodes()))
+	}
+	if lb.GetNodes()[0].GetID() != "dest-2" {
+		t.Errorf("expected remaining node to be dest-2, got %s", lb.GetNodes()[0].GetID())
+	}
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -1,0 +1,98 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"testing"
+	"time"
+)
+
+func TestMiddlewares_Logging(t *testing.T) {
+	n := node.NewBaseNode("log-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	n.Use(node.LoggingMiddleware)
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("logged"), nil
+	})
+
+	res, err := n.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(res) != "logged" {
+		t.Errorf("expected logged, got %s", string(res))
+	}
+}
+
+func TestMiddlewares_Retry_Success(t *testing.T) {
+	n := node.NewBaseNode("retry-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	n.Use(node.RetryMiddleware(3, 10*time.Millisecond))
+
+	attempts := 0
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		attempts++
+		if attempts < 3 {
+			return nil, errors.New("temporary error")
+		}
+		return []byte("success"), nil
+	})
+
+	res, err := n.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(res) != "success" {
+		t.Errorf("expected success, got %s", string(res))
+	}
+	if attempts != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+}
+
+func TestMiddlewares_Retry_Failure(t *testing.T) {
+	n := node.NewBaseNode("retry-fail-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	n.Use(node.RetryMiddleware(2, 5*time.Millisecond))
+
+	attempts := 0
+	expectedErr := errors.New("persistent error")
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		attempts++
+		return nil, expectedErr
+	})
+
+	_, err := n.Process([]byte("input"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if attempts != 3 { // initial + 2 retries
+		t.Errorf("expected 3 attempts, got %d", attempts)
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("expected error to wrap expectedErr")
+	}
+}
+
+func TestMiddlewares_Recovery(t *testing.T) {
+	n := node.NewBaseNode("recovery-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	n.Use(node.RecoveryMiddleware)
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		panic("test panic")
+	})
+
+	_, err := n.Process([]byte("input"))
+	if err == nil {
+		t.Fatalf("expected error from panic recovery, got nil")
+	}
+	if err.Error() != "test panic" {
+		t.Errorf("expected 'test panic', got '%v'", err.Error())
+	}
+}

--- a/node/tests/pipeline_test.go
+++ b/node/tests/pipeline_test.go
@@ -1,0 +1,84 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"testing"
+)
+
+func TestPipelineNode_SequentialProcessing(t *testing.T) {
+	p := node.NewPipelineNode("pipe-1")
+	node1 := node.NewBaseNode("stage-1")
+	node2 := node.NewBaseNode("stage-2")
+	node3 := node.NewBaseNode("stage-3")
+
+	var nodes []node.Node
+	nodes = append(nodes, p, node1, node2, node3)
+	defer cleanupNodes(t, nodes)
+
+	node1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append(input, []byte("-s1")...), nil
+	})
+	node2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append(input, []byte("-s2")...), nil
+	})
+	node3.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append(input, []byte("-s3")...), nil
+	})
+
+	p.AddStage(node1)
+	p.AddStage(node2)
+	p.AddStage(node3)
+
+	res, err := p.Process([]byte("data"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "data-s1-s2-s3"
+	if string(res) != expected {
+		t.Errorf("expected %s, got %s", expected, string(res))
+	}
+}
+
+func TestPipelineNode_Empty(t *testing.T) {
+	p := node.NewPipelineNode("pipe-empty")
+	defer cleanupNodes(t, []node.Node{p})
+
+	_, err := p.Process([]byte("data"))
+	if !errors.Is(err, node.ErrEmptyPipeline) {
+		t.Errorf("expected ErrEmptyPipeline, got %v", err)
+	}
+}
+
+func TestPipelineNode_ErrorPropagation(t *testing.T) {
+	p := node.NewPipelineNode("pipe-err")
+	node1 := node.NewBaseNode("stage-1")
+	node2 := node.NewBaseNode("stage-err")
+	node3 := node.NewBaseNode("stage-3")
+
+	var nodes []node.Node
+	nodes = append(nodes, p, node1, node2, node3)
+	defer cleanupNodes(t, nodes)
+
+	expectedErr := errors.New("stage 2 error")
+
+	node1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append(input, []byte("-s1")...), nil
+	})
+	node2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, expectedErr
+	})
+	node3.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append(input, []byte("-s3")...), nil
+	})
+
+	p.AddStage(node1)
+	p.AddStage(node2)
+	p.AddStage(node3)
+
+	_, err := p.Process([]byte("data"))
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("expected %v, got %v", expectedErr, err)
+	}
+}


### PR DESCRIPTION
This PR introduces advanced node types and common middlewares to the `node` package, enabling the construction of complex, scalable, and fault-tolerant node topologies.

Features included:
* **LoadBalancerNode**: A node that delegates processing to a list of underlying nodes in a thread-safe round-robin fashion, suitable for scaling request handling.
* **PipelineNode**: A node that executes a sequential chain of nodes, passing the output of one as the input to the next. Great for creating complex multi-step data transformations.
* **FailoverNode**: Adds resilience by routing data to a primary node and seamlessly catching errors to try a designated fallback node instead.
* **Middlewares**: Three utility middlewares were added:
  * `LoggingMiddleware`: Logs input size, output size, and execution duration.
  * `RetryMiddleware`: Automatically retries a failed step given a number of attempts and a delay.
  * `RecoveryMiddleware`: Gracefully catches and converts unexpected panics into regular errors to keep the application stable.

Comprehensive unit tests were added to ensure the safety and reliability of all logic, making correct use of atomic operations and `sync.RWMutex` to ensure thread safety without lock contention.

---
*PR created automatically by Jules for task [6571944913066555873](https://jules.google.com/task/6571944913066555873) started by @lhemerly*