### PR TITLE
fix: trigger CI release on main for commit messages with version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,12 +85,25 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: [test, build]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || (github.ref == 'refs/heads/main' && contains(github.event.head_commit.message, 'Release v'))
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Extract Release Tag
+        id: extract_tag
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          else
+            TAG=$(echo "$COMMIT_MSG" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?' | head -1)
+            echo "RELEASE_TAG=$TAG" >> $GITHUB_ENV
+          fi
+
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           generate_release_notes: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,16 @@ jobs:
           if [[ "${{ github.ref }}" == refs/tags/* ]]; then
             echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           else
-            TAG=$(echo "$COMMIT_MSG" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?' | head -1)
-            echo "RELEASE_TAG=$TAG" >> $GITHUB_ENV
+            TAG=$(echo "$COMMIT_MSG" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?' | head -1 || true)
+            if [ -n "$TAG" ]; then
+              echo "RELEASE_TAG=$TAG" >> $GITHUB_ENV
+            else
+              echo "No valid version tag found in commit message. Skipping release."
+            fi
           fi
 
       - name: Create Release
+        if: env.RELEASE_TAG != ''
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ env.RELEASE_TAG }}


### PR DESCRIPTION
The release job previously only fired on direct `v*` tag pushes. Now, it also triggers on pushes to `main` if the commit message contains "Release v".

- Updated `if` condition in `ci.yml` release job.
- Added `Extract Release Tag` step to parse the semantic version using grep from the commit message.
- Passed `github.event.head_commit.message` through an environment variable to prevent command injection vulnerabilities.
- Explicitly specified `tag_name: ${{ env.RELEASE_TAG }}` in the `softprops/action-gh-release` step.
- Included an empty commit to trigger `Release v0.2.1` upon merge.

---
*PR created automatically by Jules for task [1204489646145279878](https://jules.google.com/task/1204489646145279878) started by @lhemerly*