### PR TITLE
🧪 Add test for removing non-existent node in LoadBalancerNode

### DIFF
--- a/node/tests/load_balancer_test.go
+++ b/node/tests/load_balancer_test.go
@@ -69,3 +69,23 @@ func TestLoadBalancerNode_RemoveNode(t *testing.T) {
 		t.Errorf("expected remaining node to be dest-2, got %s", lb.GetNodes()[0].GetID())
 	}
 }
+
+func TestLoadBalancerNode_RemoveNonExistentNode(t *testing.T) {
+	lb := node.NewLoadBalancerNode("lb-rm-nonexistent")
+	node1 := node.NewBaseNode("dest-1")
+
+	var nodes []node.Node
+	nodes = append(nodes, lb, node1)
+	defer cleanupNodes(t, nodes)
+
+	lb.AddNode(node1)
+
+	lb.RemoveNode("non-existent-dest")
+
+	if len(lb.GetNodes()) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(lb.GetNodes()))
+	}
+	if lb.GetNodes()[0].GetID() != "dest-1" {
+		t.Errorf("expected remaining node to be dest-1, got %s", lb.GetNodes()[0].GetID())
+	}
+}


### PR DESCRIPTION
🎯 **What:** Added a unit test to verify the boundary case in `LoadBalancerNode.RemoveNode` where the node ID being removed does not exist.
📊 **Coverage:** Tests that attempting to remove a non-existent node from the load balancer pool does not cause a panic and preserves the existing nodes in the pool.
✨ **Result:** Improved test coverage and reliability for `LoadBalancerNode` edge cases.

---
*PR created automatically by Jules for task [1240588417454380139](https://jules.google.com/task/1240588417454380139) started by @lhemerly*