### PR TITLE
feat: Add new advanced nodes, rate limiter middleware, and wildcard event topics

### DIFF
--- a/event/dispatcher.go
+++ b/event/dispatcher.go
@@ -1,6 +1,7 @@
 package event
 
 import (
+	"strings"
 	"sync"
 )
 
@@ -29,17 +30,46 @@ func (d *EventDispatcher) RegisterListener(eventType string, listener func(Event
 	d.listeners[eventType] = append(d.listeners[eventType], listener)
 }
 
-// Dispatch sends event to every listener registered for event.GetType().
+// matchTopic determines if a dispatched topic matches a registered pattern.
+// Supported wildcard: '*' matches a single segment (or rest of string if last).
+func matchTopic(pattern, topic string) bool {
+	if pattern == "*" {
+		return true
+	}
+
+	pParts := strings.Split(pattern, ".")
+	tParts := strings.Split(topic, ".")
+
+	for i, p := range pParts {
+		if p == "*" {
+			// If '*' is the last part of the pattern, it matches everything remaining.
+			if i == len(pParts)-1 {
+				return true
+			}
+			continue
+		}
+		if i >= len(tParts) || p != tParts[i] {
+			return false
+		}
+	}
+
+	return len(pParts) == len(tParts)
+}
+
+// Dispatch sends event to every listener whose registered pattern matches event.GetType().
 // Each listener is called in a separate goroutine so that slow listeners
 // cannot block each other. Dispatch waits for all listener goroutines to
 // finish before returning, giving callers a clear synchronisation point.
 func (d *EventDispatcher) Dispatch(event Event) {
+	evtType := event.GetType()
+
 	d.mu.RLock()
-	listeners := d.listeners[event.GetType()]
-	// Copy the slice under the read-lock so we can release the lock before
-	// spawning goroutines, keeping the critical section short.
-	targets := make([]func(Event), len(listeners))
-	copy(targets, listeners)
+	var targets []func(Event)
+	for pattern, funcs := range d.listeners {
+		if pattern == evtType || matchTopic(pattern, evtType) {
+			targets = append(targets, funcs...)
+		}
+	}
 	d.mu.RUnlock()
 
 	var wg sync.WaitGroup

--- a/event/tests/event_dispatcher_test.go
+++ b/event/tests/event_dispatcher_test.go
@@ -29,6 +29,78 @@ func TestEventDispatcher_NilData(t *testing.T) {
 	}
 }
 
+func TestEventDispatcher_PatternMatching(t *testing.T) {
+	dispatcher := event.NewEventDispatcher()
+	var (
+		mu           sync.Mutex
+		matchedTypes []string
+	)
+
+	// Register a listener with a pattern
+	dispatcher.RegisterListener("sensor.*.temperature", func(e event.Event) {
+		mu.Lock()
+		matchedTypes = append(matchedTypes, e.GetType())
+		mu.Unlock()
+	})
+
+	dispatcher.RegisterListener("sensor.kitchen.*", func(e event.Event) {
+		mu.Lock()
+		matchedTypes = append(matchedTypes, e.GetType())
+		mu.Unlock()
+	})
+
+	dispatcher.RegisterListener("*", func(e event.Event) {
+		mu.Lock()
+		matchedTypes = append(matchedTypes, "wildcard:"+e.GetType())
+		mu.Unlock()
+	})
+
+	dispatcher.RegisterListener("sensor", func(e event.Event) {
+		mu.Lock()
+		matchedTypes = append(matchedTypes, "exact:"+e.GetType())
+		mu.Unlock()
+	})
+
+	// Dispatch an event matching "sensor.*.temperature"
+	dispatcher.Dispatch(event.NewBaseEvent("sensor.livingroom.temperature", nil))
+
+	// Dispatch an event matching "sensor.kitchen.*"
+	dispatcher.Dispatch(event.NewBaseEvent("sensor.kitchen.humidity", nil))
+
+	// Dispatch an exact event
+	dispatcher.Dispatch(event.NewBaseEvent("sensor", nil))
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// "sensor.livingroom.temperature" should match "sensor.*.temperature" and "*"
+	// "sensor.kitchen.humidity" should match "sensor.kitchen.*" and "*"
+	// "sensor" should match "sensor" and "*"
+
+	if len(matchedTypes) != 6 {
+		t.Fatalf("expected 6 matches, got %d. Matches: %v", len(matchedTypes), matchedTypes)
+	}
+
+	expectedMatches := map[string]bool{
+		"sensor.livingroom.temperature":          false,
+		"wildcard:sensor.livingroom.temperature": false,
+		"sensor.kitchen.humidity":                false,
+		"wildcard:sensor.kitchen.humidity":       false,
+		"exact:sensor":                           false,
+		"wildcard:sensor":                        false,
+	}
+
+	for _, m := range matchedTypes {
+		expectedMatches[m] = true
+	}
+
+	for k, v := range expectedMatches {
+		if !v {
+			t.Errorf("expected match %s was not triggered", k)
+		}
+	}
+}
+
 // TestEventDispatcher_RegisterAndDispatch verifies that a single listener
 // receives the dispatched event with the correct type and data.
 func TestEventDispatcher_RegisterAndDispatch(t *testing.T) {

--- a/node/dag_node.go
+++ b/node/dag_node.go
@@ -1,0 +1,170 @@
+package node
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+)
+
+// DAGNode allows executing a Directed Acyclic Graph of nodes.
+// Each node can have dependencies, and it will only be executed after
+// all its dependencies have successfully executed. The outputs of the dependencies
+// are concatenated and passed as input to the node. If a node has no dependencies,
+// it receives the initial input passed to the DAGNode.
+type DAGNode struct {
+	*BaseNode
+	nodes        map[string]Node
+	dependencies map[string][]string
+}
+
+// NewDAGNode creates a new empty DAGNode.
+func NewDAGNode(id string) *DAGNode {
+	d := &DAGNode{
+		BaseNode:     NewBaseNode(id),
+		nodes:        make(map[string]Node),
+		dependencies: make(map[string][]string),
+	}
+	d.SetProcessFunc(d.processDAG)
+	return d
+}
+
+// AddNode adds a node to the DAG with its dependencies.
+func (d *DAGNode) AddNode(node Node, deps ...string) {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.nodes[node.GetID()] = node
+	d.dependencies[node.GetID()] = deps
+}
+
+// Create initializes all nodes in the DAG.
+func (d *DAGNode) Create() error {
+	if err := d.BaseNode.Create(); err != nil {
+		return err
+	}
+	for _, n := range d.nodes {
+		if err := n.Create(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Delete cleans up all nodes in the DAG.
+func (d *DAGNode) Delete() error {
+	var errs []error
+	if err := d.BaseNode.Delete(); err != nil {
+		errs = append(errs, err)
+	}
+	for _, n := range d.nodes {
+		if err := n.Delete(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func (d *DAGNode) processDAG(input []byte) ([]byte, error) {
+	d.mutex.RLock()
+	nodesCount := len(d.nodes)
+	nodesMap := make(map[string]Node, nodesCount)
+	depsMap := make(map[string][]string, nodesCount)
+
+	for k, v := range d.nodes {
+		nodesMap[k] = v
+	}
+	for k, v := range d.dependencies {
+		depsMap[k] = v
+	}
+	d.mutex.RUnlock()
+
+	// Track results and errors for each node
+	var (
+		resultsMutex sync.Mutex
+		results      = make(map[string][]byte)
+		nodeErrs     []error
+		doneChans    = make(map[string]chan struct{})
+	)
+
+	for id := range nodesMap {
+		doneChans[id] = make(chan struct{})
+	}
+
+	var wg sync.WaitGroup
+
+	for id, n := range nodesMap {
+		wg.Add(1)
+		go func(nodeID string, node Node) {
+			defer wg.Done()
+			defer close(doneChans[nodeID])
+
+			deps := depsMap[nodeID]
+
+			// Wait for dependencies to finish
+			for _, depID := range deps {
+				if depChan, exists := doneChans[depID]; exists {
+					<-depChan
+				}
+			}
+
+			resultsMutex.Lock()
+			hasErr := len(nodeErrs) > 0
+			resultsMutex.Unlock()
+
+			// If any dependency (or any other node) failed, short-circuit
+			if hasErr {
+				return
+			}
+
+			// Gather inputs
+			var nodeInput []byte
+			if len(deps) == 0 {
+				nodeInput = make([]byte, len(input))
+				copy(nodeInput, input)
+			} else {
+				var buf bytes.Buffer
+				resultsMutex.Lock()
+				for _, depID := range deps {
+					buf.Write(results[depID])
+				}
+				resultsMutex.Unlock()
+				nodeInput = buf.Bytes()
+			}
+
+			out, err := node.Process(nodeInput)
+
+			resultsMutex.Lock()
+			if err != nil {
+				nodeErrs = append(nodeErrs, err)
+			} else {
+				results[nodeID] = out
+			}
+			resultsMutex.Unlock()
+		}(id, n)
+	}
+
+	wg.Wait()
+
+	if len(nodeErrs) > 0 {
+		return nil, errors.Join(append([]error{errors.New("DAG execution failed")}, nodeErrs...)...)
+	}
+
+	// Determine leaf nodes (nodes that are not dependencies for any other node)
+	isDep := make(map[string]bool)
+	for _, deps := range depsMap {
+		for _, dep := range deps {
+			isDep[dep] = true
+		}
+	}
+
+	var finalOutput bytes.Buffer
+	for id := range nodesMap {
+		if !isDep[id] {
+			finalOutput.Write(results[id])
+		}
+	}
+
+	return finalOutput.Bytes(), nil
+}

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +58,39 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimiterMiddleware limits the number of requests processed per second using a simple token bucket algorithm.
+func RateLimiterMiddleware(rate int, burst int) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64 = float64(burst)
+		lastRefill         = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+			now := time.Now()
+			elapsed := now.Sub(lastRefill).Seconds()
+
+			// Refill tokens
+			tokens += elapsed * float64(rate)
+			if tokens > float64(burst) {
+				tokens = float64(burst)
+			}
+			lastRefill = now
+
+			if tokens < 1 {
+				mu.Unlock()
+				return nil, ErrRateLimitExceeded
+			}
+			tokens--
+			mu.Unlock()
+
+			return next(input)
 		}
 	}
 }

--- a/node/tests/dag_node_test.go
+++ b/node/tests/dag_node_test.go
@@ -1,0 +1,80 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"strings"
+	"testing"
+)
+
+func TestDAGNode(t *testing.T) {
+	dag := node.NewDAGNode("dag")
+	defer cleanupNodes(t, []node.Node{dag})
+
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(in []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+
+	n2 := node.NewBaseNode("n2")
+	n2.SetProcessFunc(func(in []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+
+	n3 := node.NewBaseNode("n3")
+	n3.SetProcessFunc(func(in []byte) ([]byte, error) {
+		return append(in, []byte("C")...), nil
+	})
+
+	dag.AddNode(n1)
+	dag.AddNode(n2)
+	dag.AddNode(n3, "n1", "n2") // n3 depends on n1 and n2
+
+	if err := dag.Create(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	res, err := dag.Process([]byte("initial"))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	outStr := string(res)
+	// n3 receives n1 output ("A") and n2 output ("B") concatenated.
+	// The order of concatenation in map iteration is non-deterministic in Go,
+	// so it could be "ABC" or "BAC".
+	if outStr != "ABC" && outStr != "BAC" {
+		t.Errorf("expected ABC or BAC, got %s", outStr)
+	}
+}
+
+func TestDAGNode_Failure(t *testing.T) {
+	dag := node.NewDAGNode("dag")
+	defer cleanupNodes(t, []node.Node{dag})
+
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(in []byte) ([]byte, error) {
+		return nil, errors.New("n1 failed")
+	})
+
+	n2 := node.NewBaseNode("n2")
+	n2.SetProcessFunc(func(in []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+
+	dag.AddNode(n1)
+	dag.AddNode(n2, "n1")
+
+	if err := dag.Create(); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	_, err := dag.Process([]byte("initial"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "DAG execution failed") || !strings.Contains(err.Error(), "n1 failed") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -241,6 +241,53 @@ func TestMiddlewares_Cache(t *testing.T) {
 	}
 }
 
+func TestMiddlewares_RateLimiter(t *testing.T) {
+	n := node.NewBaseNode("rate-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// 5 tokens per second, burst of 2
+	n.Use(node.RateLimiterMiddleware(5, 2))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	// Burst capacity is 2, so the first 2 should succeed immediately.
+	for i := 0; i < 2; i++ {
+		res, err := n.Process([]byte("input"))
+		if err != nil {
+			t.Fatalf("unexpected error on burst request %d: %v", i+1, err)
+		}
+		if string(res) != "success" {
+			t.Errorf("expected success, got %s", string(res))
+		}
+	}
+
+	// 3rd request should fail as bucket is empty and hasn't refilled
+	_, err := n.Process([]byte("input"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// Wait 200ms to accumulate 1 token (5 tokens/sec = 1 token per 200ms)
+	time.Sleep(210 * time.Millisecond)
+
+	// Now 1 request should succeed
+	res, err := n.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error after waiting: %v", err)
+	}
+	if string(res) != "success" {
+		t.Errorf("expected success, got %s", string(res))
+	}
+
+	// Next request should fail again
+	_, err = n.Process([]byte("input"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+}
+
 func TestMiddlewares_Timeout(t *testing.T) {
 	n := node.NewBaseNode("timeout-node")
 	defer cleanupNodes(t, []node.Node{n})

--- a/node/tests/worker_pool_node_test.go
+++ b/node/tests/worker_pool_node_test.go
@@ -1,0 +1,104 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWorkerPoolNode(t *testing.T) {
+	target := node.NewBaseNode("target")
+
+	// Fast target
+	target.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("processed: "), input...), nil
+	})
+
+	wp := node.NewWorkerPoolNode("wp", target, 2, 2)
+	defer cleanupNodes(t, []node.Node{wp})
+
+	if err := wp.Create(); err != nil {
+		t.Fatalf("unexpected error on create: %v", err)
+	}
+
+	res, err := wp.Process([]byte("data"))
+	if err != nil {
+		t.Fatalf("unexpected error on process: %v", err)
+	}
+	if string(res) != "processed: data" {
+		t.Errorf("expected 'processed: data', got '%s'", string(res))
+	}
+}
+
+func TestWorkerPoolNode_LoadShedding(t *testing.T) {
+	target := node.NewBaseNode("slow-target")
+
+	// Slow target to block workers
+	target.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond)
+		return []byte("done"), nil
+	})
+
+	// Pool size 1, Queue size 1
+	// Concurrency: 1 processing, 1 queued. 3rd should fail immediately.
+	wp := node.NewWorkerPoolNode("wp-shed", target, 1, 1)
+	defer cleanupNodes(t, []node.Node{wp})
+
+	if err := wp.Create(); err != nil {
+		t.Fatalf("unexpected error on create: %v", err)
+	}
+
+	errs := make(chan error, 3)
+	var wg sync.WaitGroup
+
+	// 1st request should be picked up by the worker and block for 100ms
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := wp.Process([]byte("data"))
+		if err != nil {
+			errs <- err
+		}
+	}()
+
+	// Wait a bit to ensure the worker has picked up the first request
+	time.Sleep(10 * time.Millisecond)
+
+	// 2nd request should fill the queue (queue size 1)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := wp.Process([]byte("data"))
+		if err != nil {
+			errs <- err
+		}
+	}()
+
+	// Wait a tiny bit to ensure the second request is in the queue
+	time.Sleep(10 * time.Millisecond)
+
+	// 3rd request should fail immediately with ErrQueueFull
+	_, err := wp.Process([]byte("data"))
+	if err != nil {
+		errs <- err
+	}
+
+	// Wait for all requests to finish processing
+	wg.Wait()
+	close(errs)
+
+	// We only expect 1 ErrQueueFull from the 3rd request
+	var queueFullErrors int
+
+	for err := range errs {
+		if errors.Is(err, node.ErrQueueFull) {
+			queueFullErrors++
+		}
+	}
+
+	if queueFullErrors != 1 {
+		t.Errorf("expected 1 ErrQueueFull error, got %d", queueFullErrors)
+	}
+}

--- a/node/worker_pool_node.go
+++ b/node/worker_pool_node.go
@@ -1,0 +1,110 @@
+package node
+
+import (
+	"errors"
+)
+
+// ErrQueueFull is returned when the WorkerPoolNode's queue is full and it sheds load.
+var ErrQueueFull = errors.New("worker pool queue is full")
+
+// WorkerPoolNode wraps another node to limit its concurrency using a bounded pool of workers.
+// It also has a queue to hold requests when all workers are busy. If the queue fills up,
+// it will shed load by returning ErrQueueFull.
+type WorkerPoolNode struct {
+	*BaseNode
+	targetNode Node
+	jobChan    chan *workerJob
+	poolSize   int
+	queueSize  int
+}
+
+type workerJob struct {
+	input []byte
+	res   chan workerResult
+}
+
+type workerResult struct {
+	output []byte
+	err    error
+}
+
+// NewWorkerPoolNode creates a new WorkerPoolNode with the given ID, target node, pool size, and queue size.
+func NewWorkerPoolNode(id string, targetNode Node, poolSize int, queueSize int) *WorkerPoolNode {
+	if poolSize <= 0 {
+		panic("WorkerPoolNode requires poolSize > 0")
+	}
+	if queueSize < 0 {
+		panic("WorkerPoolNode requires queueSize >= 0")
+	}
+	if targetNode == nil {
+		panic("WorkerPoolNode requires a non-nil targetNode")
+	}
+
+	w := &WorkerPoolNode{
+		BaseNode:   NewBaseNode(id),
+		targetNode: targetNode,
+		jobChan:    make(chan *workerJob, queueSize),
+		poolSize:   poolSize,
+		queueSize:  queueSize,
+	}
+
+	w.SetProcessFunc(w.workerPoolProcess)
+	return w
+}
+
+// Create initializes the worker pool and its target node.
+func (w *WorkerPoolNode) Create() error {
+	if err := w.BaseNode.Create(); err != nil {
+		return err
+	}
+	if err := w.targetNode.Create(); err != nil {
+		return err
+	}
+
+	// Start workers
+	for i := 0; i < w.poolSize; i++ {
+		go func() {
+			for job := range w.jobChan {
+				out, err := w.targetNode.Process(job.input)
+				job.res <- workerResult{output: out, err: err}
+			}
+		}()
+	}
+
+	return nil
+}
+
+// Delete cleans up the node and its target node.
+func (w *WorkerPoolNode) Delete() error {
+	close(w.jobChan)
+	var errs []error
+	if err := w.BaseNode.Delete(); err != nil {
+		errs = append(errs, err)
+	}
+	if err := w.targetNode.Delete(); err != nil {
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+// workerPoolProcess delegates the processing to the worker pool.
+func (w *WorkerPoolNode) workerPoolProcess(input []byte) ([]byte, error) {
+	resChan := make(chan workerResult, 1)
+	job := &workerJob{
+		input: input,
+		res:   resChan,
+	}
+
+	select {
+	case w.jobChan <- job:
+		// Job accepted into queue
+		res := <-resChan
+		return res.output, res.err
+	default:
+		// Queue is full, shed load
+		return nil, ErrQueueFull
+	}
+}


### PR DESCRIPTION
Introduces `RateLimiterMiddleware`, `WorkerPoolNode`, `DAGNode`, and wildcard topic pattern matching for `EventDispatcher`. Includes tests and concurrency race fixes.

---
*PR created automatically by Jules for task [17410435612646148738](https://jules.google.com/task/17410435612646148738) started by @lhemerly*