### PR TITLE
Add RateLimitMiddleware, FilterMiddleware and AggregatorNode

### DIFF
--- a/node/aggregator_node.go
+++ b/node/aggregator_node.go
@@ -1,0 +1,123 @@
+package node
+
+import (
+	"bytes"
+	"sync"
+	"time"
+)
+
+// AggregatorNode collects incoming messages into batches.
+// It flushes a batch by aggregating it with an aggregator function and then
+// notifying subscribers, when either the batch size is met or the flush interval triggers.
+type AggregatorNode struct {
+	*BaseNode
+	batchSize     int
+	flushInterval time.Duration
+	aggregator    func([][]byte) []byte
+
+	mu       sync.Mutex
+	batch    [][]byte
+	stopChan chan struct{}
+	wg       sync.WaitGroup
+}
+
+// NewAggregatorNode creates a new AggregatorNode.
+func NewAggregatorNode(id string, batchSize int, flushInterval time.Duration, aggregator func([][]byte) []byte) *AggregatorNode {
+	an := &AggregatorNode{
+		BaseNode:      NewBaseNode(id),
+		batchSize:     batchSize,
+		flushInterval: flushInterval,
+		aggregator:    aggregator,
+		batch:         make([][]byte, 0, batchSize),
+		stopChan:      make(chan struct{}),
+	}
+
+	an.SetProcessFunc(an.process)
+	return an
+}
+
+// Create starts the background ticker for time-based flushing.
+func (an *AggregatorNode) Create() error {
+	if err := an.BaseNode.Create(); err != nil {
+		return err
+	}
+
+	an.wg.Add(1)
+	go an.flushLoop()
+	return nil
+}
+
+// Delete stops the background ticker and releases resources.
+func (an *AggregatorNode) Delete() error {
+	close(an.stopChan)
+	an.wg.Wait()
+	return an.BaseNode.Delete()
+}
+
+func (an *AggregatorNode) process(input []byte) ([]byte, error) {
+	an.mu.Lock()
+
+	// Create a copy to prevent external mutation
+	inputCopy := make([]byte, len(input))
+	copy(inputCopy, input)
+
+	an.batch = append(an.batch, inputCopy)
+
+	if len(an.batch) >= an.batchSize {
+		batchToFlush := an.batch
+		an.batch = make([][]byte, 0, an.batchSize)
+		an.mu.Unlock()
+
+		an.flush(batchToFlush)
+		return nil, nil // Return immediately after processing
+	}
+
+	an.mu.Unlock()
+	return nil, nil
+}
+
+func (an *AggregatorNode) flushLoop() {
+	defer an.wg.Done()
+	ticker := time.NewTicker(an.flushInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			an.mu.Lock()
+			if len(an.batch) > 0 {
+				batchToFlush := an.batch
+				an.batch = make([][]byte, 0, an.batchSize)
+				an.mu.Unlock()
+				an.flush(batchToFlush)
+			} else {
+				an.mu.Unlock()
+			}
+		case <-an.stopChan:
+			// Flush any remaining items before stopping
+			an.mu.Lock()
+			if len(an.batch) > 0 {
+				batchToFlush := an.batch
+				an.batch = nil
+				an.mu.Unlock()
+				an.flush(batchToFlush)
+			} else {
+				an.mu.Unlock()
+			}
+			return
+		}
+	}
+}
+
+func (an *AggregatorNode) flush(batch [][]byte) {
+	if len(batch) == 0 {
+		return
+	}
+	aggregatedData := an.aggregator(batch)
+	_ = an.Notify(aggregatedData)
+}
+
+// DefaultAggregator is a simple aggregator that joins bytes with a newline.
+func DefaultAggregator(batch [][]byte) []byte {
+	return bytes.Join(batch, []byte("\n"))
+}

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,7 +12,58 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
+	ErrMessageFiltered    = errors.New("message filtered")
 )
+
+// FilterMiddleware drops messages that do not pass a predicate function.
+func FilterMiddleware(predicate func([]byte) bool) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			if !predicate(input) {
+				return nil, ErrMessageFiltered
+			}
+			return next(input)
+		}
+	}
+}
+
+// RateLimitMiddleware limits the rate of processing requests using a simple token bucket.
+// It allows a burst of requests up to capacity, and refills tokens at the specified rate (tokens per second).
+func RateLimitMiddleware(rate float64, capacity int) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64   = float64(capacity)
+		lastRefill time.Time = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+			now := time.Now()
+			elapsed := now.Sub(lastRefill).Seconds()
+
+			// Refill tokens
+			tokens += elapsed * rate
+			if tokens > float64(capacity) {
+				tokens = float64(capacity)
+			}
+			lastRefill = now
+
+			// Check if we have enough tokens
+			if tokens < 1.0 {
+				mu.Unlock()
+				return nil, ErrRateLimitExceeded
+			}
+
+			// Consume a token
+			tokens -= 1.0
+			mu.Unlock()
+
+			return next(input)
+		}
+	}
+}
 
 // LoggingMiddleware logs the payload size and processing time.
 func LoggingMiddleware(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {

--- a/node/tests/aggregator_node_test.go
+++ b/node/tests/aggregator_node_test.go
@@ -1,0 +1,128 @@
+package node_test
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestAggregatorNode_SizeFlush(t *testing.T) {
+	// Simple join aggregator
+	aggregator := func(batch [][]byte) []byte {
+		return bytes.Join(batch, []byte(","))
+	}
+
+	aggNode := node.NewAggregatorNode("agg1", 3, 1*time.Hour, aggregator)
+	_ = aggNode.Create()
+	defer cleanupNodes(t, []*node.AggregatorNode{aggNode})
+
+	// Subscriber node to capture output
+	var mu sync.Mutex
+	var received []byte
+	subNode := node.NewBaseNode("sub1")
+	subNode.SetProcessFunc(func(input []byte) ([]byte, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, input...)
+		return nil, nil
+	})
+	_ = aggNode.Subscribe(subNode)
+
+	// Send 2 messages (should not flush)
+	_, _ = aggNode.Process([]byte("A"))
+	_, _ = aggNode.Process([]byte("B"))
+
+	mu.Lock()
+	if len(received) > 0 {
+		t.Fatalf("Expected no flush yet, got %s", received)
+	}
+	mu.Unlock()
+
+	// Send 3rd message (should flush)
+	_, _ = aggNode.Process([]byte("C"))
+
+	// Give time for async notify to finish
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	if string(received) != "A,B,C" {
+		t.Fatalf("Expected 'A,B,C', got '%s'", received)
+	}
+	mu.Unlock()
+}
+
+func TestAggregatorNode_TimeFlush(t *testing.T) {
+	aggregator := func(batch [][]byte) []byte {
+		return bytes.Join(batch, []byte("-"))
+	}
+
+	aggNode := node.NewAggregatorNode("agg2", 10, 100*time.Millisecond, aggregator)
+	_ = aggNode.Create()
+	defer cleanupNodes(t, []*node.AggregatorNode{aggNode})
+
+	var mu sync.Mutex
+	var received []byte
+	subNode := node.NewBaseNode("sub2")
+	subNode.SetProcessFunc(func(input []byte) ([]byte, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, input...)
+		return nil, nil
+	})
+	_ = aggNode.Subscribe(subNode)
+
+	// Send messages under batch size
+	_, _ = aggNode.Process([]byte("X"))
+	_, _ = aggNode.Process([]byte("Y"))
+
+	// Wait for ticker to flush
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	if string(received) != "X-Y" {
+		t.Fatalf("Expected 'X-Y', got '%s'", received)
+	}
+	mu.Unlock()
+}
+
+func TestAggregatorNode_Concurrency(t *testing.T) {
+	aggNode := node.NewAggregatorNode("agg3", 50, 1*time.Hour, node.DefaultAggregator)
+	_ = aggNode.Create()
+	defer cleanupNodes(t, []*node.AggregatorNode{aggNode})
+
+	var mu sync.Mutex
+	var received []byte
+	subNode := node.NewBaseNode("sub3")
+	subNode.SetProcessFunc(func(input []byte) ([]byte, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		received = append(received, input...)
+		received = append(received, []byte("\n")...)
+		return nil, nil
+	})
+	_ = aggNode.Subscribe(subNode)
+
+	var wg sync.WaitGroup
+	// 50 goroutines sending 1 message each
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = aggNode.Process([]byte("M"))
+		}()
+	}
+
+	wg.Wait()
+	time.Sleep(50 * time.Millisecond) // Wait for notify
+
+	mu.Lock()
+	count := strings.Count(string(received), "M")
+	if count != 50 {
+		t.Fatalf("Expected 50 'M's, got %d", count)
+	}
+	mu.Unlock()
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -314,3 +314,63 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
 	}
 }
+
+func TestRateLimitMiddleware(t *testing.T) {
+	mockProcess := func(input []byte) ([]byte, error) {
+		return input, nil
+	}
+
+	// 10 tokens per second, max 1 burst
+	rateLimiter := node.RateLimitMiddleware(10, 1)
+	process := rateLimiter(mockProcess)
+
+	// First request should succeed
+	_, err := process([]byte("test"))
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Second request immediately after should fail (exceed capacity)
+	_, err = process([]byte("test"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("Expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// Wait for a token to be refilled (1/10th of a sec + a little extra)
+	time.Sleep(150 * time.Millisecond)
+
+	// Third request should succeed
+	_, err = process([]byte("test"))
+	if err != nil {
+		t.Fatalf("Expected no error after waiting, got %v", err)
+	}
+}
+
+func TestFilterMiddleware(t *testing.T) {
+	mockProcess := func(input []byte) ([]byte, error) {
+		return input, nil
+	}
+
+	// Predicate: only pass inputs longer than 3 bytes
+	predicate := func(input []byte) bool {
+		return len(input) > 3
+	}
+
+	filter := node.FilterMiddleware(predicate)
+	process := filter(mockProcess)
+
+	// Should succeed (length 4 > 3)
+	out, err := process([]byte("abcd"))
+	if err != nil {
+		t.Fatalf("Expected no error for passing input, got %v", err)
+	}
+	if string(out) != "abcd" {
+		t.Fatalf("Expected output abcd, got %s", out)
+	}
+
+	// Should fail (length 3 <= 3)
+	_, err = process([]byte("abc"))
+	if !errors.Is(err, node.ErrMessageFiltered) {
+		t.Fatalf("Expected ErrMessageFiltered, got %v", err)
+	}
+}


### PR DESCRIPTION
- Add RateLimitMiddleware using a token bucket approach to allow burst control.
- Add FilterMiddleware to prevent messages not matching a boolean predicate from continuing the chain.
- Add an AggregatorNode node type which embeds a BaseNode and batches messages. Flush triggers happen based on size or time criteria configured via its constructor.
- Fix potential data race / panic in AggregatorNode by using a sync.WaitGroup ensuring the teardown of flushLoop is synced.
- Add tests to ensure code coverage and behavior match design intent.

---
*PR created automatically by Jules for task [14865353249165392802](https://jules.google.com/task/14865353249165392802) started by @lhemerly*