### PR TITLE
feat: Add creative middlewares and ScheduledNode

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -1,9 +1,12 @@
 package node
 
 import (
+	"bytes"
+	"compress/gzip"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"io"
 	"log"
 	"sync"
 	"time"
@@ -57,6 +60,112 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+var (
+	ErrFiltered             = errors.New("input filtered out")
+	ErrRateLimitExceeded    = errors.New("rate limit exceeded")
+)
+
+// FilterMiddleware filters out inputs that do not satisfy the predicate function.
+func FilterMiddleware(predicate func([]byte) bool) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			if !predicate(input) {
+				return nil, ErrFiltered
+			}
+			return next(input)
+		}
+	}
+}
+
+// ConcurrencyLimitMiddleware limits the number of concurrent executions of the processing function.
+func ConcurrencyLimitMiddleware(maxConcurrent int) Middleware {
+	sem := make(chan struct{}, maxConcurrent)
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			return next(input)
+		}
+	}
+}
+
+// RateLimitMiddleware limits the rate of processing using a simple token bucket.
+func RateLimitMiddleware(requestsPerSecond int) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     int
+		lastRefill time.Time
+	)
+	tokens = requestsPerSecond
+	lastRefill = time.Now()
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+			now := time.Now()
+			elapsed := now.Sub(lastRefill)
+			tokensToAdd := int(elapsed.Seconds() * float64(requestsPerSecond))
+
+			if tokensToAdd > 0 {
+				tokens += tokensToAdd
+				if tokens > requestsPerSecond {
+					tokens = requestsPerSecond
+				}
+				lastRefill = now
+			}
+
+			if tokens <= 0 {
+				mu.Unlock()
+				return nil, ErrRateLimitExceeded
+			}
+
+			tokens--
+			mu.Unlock()
+
+			return next(input)
+		}
+	}
+}
+
+// CompressionMiddleware compresses the output and decompresses the input.
+// This is a basic implementation placeholder. In a real scenario, you'd use compress/gzip.
+
+func CompressionMiddleware() Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			// Decompress input
+			reader, err := gzip.NewReader(bytes.NewReader(input))
+			var decompressedInput []byte
+			if err == nil {
+				decompressedInput, err = io.ReadAll(reader)
+				reader.Close()
+			}
+
+			// If decompression fails (e.g. not gzip data), just use the original input
+			if err != nil {
+				decompressedInput = input
+			}
+
+			// Process
+			output, err := next(decompressedInput)
+			if err != nil || output == nil {
+				return output, err
+			}
+
+			// Compress output
+			var buf bytes.Buffer
+			writer := gzip.NewWriter(&buf)
+			_, err = writer.Write(output)
+			if err != nil {
+				writer.Close()
+				return output, err
+			}
+			writer.Close()
+			return buf.Bytes(), nil
 		}
 	}
 }

--- a/node/scheduled_node.go
+++ b/node/scheduled_node.go
@@ -1,0 +1,92 @@
+package node
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// ScheduledNode represents a node that acts as a periodic event source.
+// It executes its process function on a defined interval, notifying its subscribers
+// with the output.
+type ScheduledNode struct {
+	*BaseNode
+	interval time.Duration
+	ctx      context.Context
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	mu       sync.Mutex
+	running  bool
+}
+
+// NewScheduledNode creates a new ScheduledNode with the given ID and interval.
+func NewScheduledNode(id string, interval time.Duration) *ScheduledNode {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &ScheduledNode{
+		BaseNode: NewBaseNode(id),
+		interval: interval,
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+}
+
+// Create starts the internal timer that triggers the process function periodically.
+func (sn *ScheduledNode) Create() error {
+	if err := sn.BaseNode.Create(); err != nil {
+		return err
+	}
+
+	sn.mu.Lock()
+	defer sn.mu.Unlock()
+
+	if sn.running {
+		return nil
+	}
+	sn.running = true
+
+	// In case Create is called again after Delete
+	if sn.ctx.Err() != nil {
+		sn.ctx, sn.cancel = context.WithCancel(context.Background())
+	}
+
+	sn.wg.Add(1)
+	go sn.run()
+
+	return nil
+}
+
+// Delete stops the internal timer and waits for the goroutine to finish.
+func (sn *ScheduledNode) Delete() error {
+	sn.mu.Lock()
+	if !sn.running {
+		sn.mu.Unlock()
+		return sn.BaseNode.Delete()
+	}
+	sn.running = false
+	sn.cancel()
+	sn.mu.Unlock()
+
+	sn.wg.Wait()
+	return sn.BaseNode.Delete()
+}
+
+// run is the background loop that executes on the configured interval.
+func (sn *ScheduledNode) run() {
+	defer sn.wg.Done()
+	ticker := time.NewTicker(sn.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-sn.ctx.Done():
+			return
+		case <-ticker.C:
+			// Process an empty payload or a timestamp. For flexibility, pass empty.
+			output, err := sn.Process(nil)
+			if err == nil && output != nil {
+				// Broadcast the result to subscribers
+				_ = sn.Notify(output)
+			}
+		}
+	}
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -1,8 +1,11 @@
 package node_test
 
 import (
+	"bytes"
 	"errors"
 	"github.com/lhemerly/Constellation/node"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -312,5 +315,149 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 	_, err = n.Process([]byte{})
 	if !errors.Is(err, node.ErrCircuitBreakerOpen) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
+	}
+}
+
+func TestMiddlewares_Filter(t *testing.T) {
+	n := node.NewBaseNode("filter-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	n.Use(node.FilterMiddleware(func(input []byte) bool {
+		return string(input) == "valid"
+	}))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("processed"), nil
+	})
+
+	// Valid input
+	res, err := n.Process([]byte("valid"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(res) != "processed" {
+		t.Errorf("expected processed, got %s", string(res))
+	}
+
+	// Invalid input
+	res, err = n.Process([]byte("invalid"))
+	if !errors.Is(err, node.ErrFiltered) {
+		t.Fatalf("expected ErrFiltered, got %v", err)
+	}
+	if res != nil {
+		t.Errorf("expected nil result, got %s", string(res))
+	}
+}
+
+func TestMiddlewares_ConcurrencyLimit(t *testing.T) {
+	n := node.NewBaseNode("concurrency-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	n.Use(node.ConcurrencyLimitMiddleware(2))
+
+	var currentConcurrent int32
+	var maxObservedConcurrent int32
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		// Increment concurrent counter
+		current := atomic.AddInt32(&currentConcurrent, 1)
+		defer atomic.AddInt32(&currentConcurrent, -1)
+
+		// Record max observed
+		for {
+			maxObserved := atomic.LoadInt32(&maxObservedConcurrent)
+			if current <= maxObserved {
+				break
+			}
+			if atomic.CompareAndSwapInt32(&maxObservedConcurrent, maxObserved, current) {
+				break
+			}
+		}
+
+		time.Sleep(10 * time.Millisecond) // Simulate work
+		return []byte("done"), nil
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = n.Process([]byte("input"))
+		}()
+	}
+	wg.Wait()
+
+	if maxObservedConcurrent > 2 {
+		t.Errorf("expected max concurrency to be 2 or less, got %d", maxObservedConcurrent)
+	}
+}
+
+func TestMiddlewares_RateLimit(t *testing.T) {
+	n := node.NewBaseNode("rate-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// 10 requests per second
+	n.Use(node.RateLimitMiddleware(10))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("ok"), nil
+	})
+
+	// Consume all 10 tokens immediately
+	for i := 0; i < 10; i++ {
+		_, err := n.Process([]byte("req"))
+		if err != nil {
+			t.Fatalf("unexpected error on request %d: %v", i, err)
+		}
+	}
+
+	// The 11th request should hit the rate limit
+	_, err := n.Process([]byte("req"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+}
+
+func TestMiddlewares_Compression(t *testing.T) {
+	n := node.NewBaseNode("compression-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	n.Use(node.CompressionMiddleware())
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		// The input should be decompressed
+		if string(input) != "raw data" {
+			t.Errorf("expected decompressed 'raw data', got '%s'", string(input))
+		}
+		return []byte("processed data"), nil
+	})
+
+	// Process without compression first, middleware should pass it as is (since it's not valid gzip)
+	res1, err := n.Process([]byte("raw data"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Output should be compressed gzip
+	if bytes.HasPrefix(res1, []byte("processed data")) {
+		t.Fatalf("expected compressed output, got plain text")
+	}
+
+	// Now pass the compressed output back in
+	// CompressionMiddleware should decompress it
+	n2 := node.NewBaseNode("compression-node-2")
+	defer cleanupNodes(t, []node.Node{n2})
+	n2.Use(node.CompressionMiddleware())
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		if string(input) != "processed data" {
+			t.Errorf("expected decompressed 'processed data', got '%s'", string(input))
+		}
+		return []byte("done"), nil
+	})
+
+	_, err = n2.Process(res1)
+	if err != nil {
+		t.Fatalf("unexpected error on second process: %v", err)
 	}
 }

--- a/node/tests/scheduled_node_test.go
+++ b/node/tests/scheduled_node_test.go
@@ -1,0 +1,71 @@
+package node_test
+
+import (
+	"github.com/lhemerly/Constellation/node"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestScheduledNode(t *testing.T) {
+	interval := 50 * time.Millisecond
+	sn := node.NewScheduledNode("scheduled-node", interval)
+	defer cleanupNodes(t, []node.Node{sn})
+
+	var executionCount int32
+	sn.SetProcessFunc(func(input []byte) ([]byte, error) {
+		atomic.AddInt32(&executionCount, 1)
+		return []byte("tick"), nil
+	})
+
+	// Add a subscriber to receive the output
+	subscriber := node.NewBaseNode("subscriber")
+	defer cleanupNodes(t, []node.Node{subscriber})
+
+	var notificationCount int32
+	subscriber.SetProcessFunc(func(input []byte) ([]byte, error) {
+		if string(input) == "tick" {
+			atomic.AddInt32(&notificationCount, 1)
+		}
+		return input, nil
+	})
+
+	err := sn.Subscribe(subscriber)
+	if err != nil {
+		t.Fatalf("unexpected error subscribing: %v", err)
+	}
+
+	err = sn.Create()
+	if err != nil {
+		t.Fatalf("unexpected error creating scheduled node: %v", err)
+	}
+
+	// Wait long enough for a few ticks to happen
+	time.Sleep(175 * time.Millisecond)
+
+	// Clean up which stops the scheduler
+	err = sn.Delete()
+	if err != nil {
+		t.Fatalf("unexpected error deleting scheduled node: %v", err)
+	}
+
+	count := atomic.LoadInt32(&executionCount)
+	notifs := atomic.LoadInt32(&notificationCount)
+
+	// In 175ms with 50ms interval, we expect roughly 3 ticks (50, 100, 150)
+	if count < 2 || count > 4 {
+		t.Errorf("expected between 2 and 4 executions, got %d", count)
+	}
+
+	if notifs < 2 || notifs > 4 {
+		t.Errorf("expected between 2 and 4 notifications, got %d", notifs)
+	}
+
+	// Ensure it stopped
+	time.Sleep(100 * time.Millisecond)
+
+	newCount := atomic.LoadInt32(&executionCount)
+	if newCount != count {
+		t.Errorf("expected execution count to remain %d after delete, but got %d", count, newCount)
+	}
+}


### PR DESCRIPTION
Adds new middlewares for resilience and flow control (`Filter`, `ConcurrencyLimit`, `RateLimit`, `Compression`), along with a `ScheduledNode` that acts as a periodic event source.

---
*PR created automatically by Jules for task [13292475675688470704](https://jules.google.com/task/13292475675688470704) started by @lhemerly*