### PR TITLE
docs: fix typo in contributing doc reference in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,7 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 


### PR DESCRIPTION
This PR fixes a small typo in `readme.md` where it referred to `CONTRIBUTING.md` which does not exist, and should be pointing to `CONTRIBUTE.md`.
It was also verified that there is no missing functionality in the codebase as opposed to what was advertised in the readme.

---
*PR created automatically by Jules for task [13745962634372931485](https://jules.google.com/task/13745962634372931485) started by @lhemerly*