### PR TITLE
✨ feat: Introduce ConsensusNode, RateLimitMiddleware, and ConcurrencyLimitMiddleware

### DIFF
--- a/node/consensus_node.go
+++ b/node/consensus_node.go
@@ -1,0 +1,133 @@
+package node
+
+import (
+	"errors"
+	"sync"
+)
+
+var (
+	// ErrNoConsensus is returned when the nodes cannot reach a majority agreement.
+	ErrNoConsensus = errors.New("no consensus reached")
+	// ErrAllNodesFailed is returned when all nodes fail to process the input.
+	ErrAllNodesFailed = errors.New("all nodes failed to process")
+)
+
+// ConsensusNode represents a node that distributes processing to multiple identical nodes
+// and returns the result agreed upon by the majority.
+type ConsensusNode struct {
+	*BaseNode
+	nodesMutex sync.RWMutex
+	nodes      []Node
+}
+
+// NewConsensusNode creates a new ConsensusNode with the given ID.
+func NewConsensusNode(id string) *ConsensusNode {
+	cn := &ConsensusNode{
+		BaseNode: NewBaseNode(id),
+		nodes:    make([]Node, 0),
+	}
+	cn.SetProcessFunc(cn.processConsensus)
+	return cn
+}
+
+// AddNode adds a node to participate in the consensus.
+func (cn *ConsensusNode) AddNode(node Node) {
+	cn.nodesMutex.Lock()
+	defer cn.nodesMutex.Unlock()
+	cn.nodes = append(cn.nodes, node)
+}
+
+// RemoveNode removes a node from the consensus pool by its ID.
+func (cn *ConsensusNode) RemoveNode(nodeID string) {
+	cn.nodesMutex.Lock()
+	defer cn.nodesMutex.Unlock()
+
+	for i, node := range cn.nodes {
+		if node.GetID() == nodeID {
+			cn.nodes = append(cn.nodes[:i], cn.nodes[i+1:]...)
+			break
+		}
+	}
+}
+
+// GetNodes returns the current list of nodes participating in consensus.
+func (cn *ConsensusNode) GetNodes() []Node {
+	cn.nodesMutex.RLock()
+	defer cn.nodesMutex.RUnlock()
+
+	nodesCopy := make([]Node, len(cn.nodes))
+	copy(nodesCopy, cn.nodes)
+	return nodesCopy
+}
+
+// processConsensus distributes the input to all nodes and determines the majority result.
+func (cn *ConsensusNode) processConsensus(input []byte) ([]byte, error) {
+	cn.nodesMutex.RLock()
+	nodesCount := len(cn.nodes)
+	if nodesCount == 0 {
+		cn.nodesMutex.RUnlock()
+		return nil, ErrNoNodes
+	}
+	nodesCopy := make([]Node, nodesCount)
+	copy(nodesCopy, cn.nodes)
+	cn.nodesMutex.RUnlock()
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	results := make([][]byte, 0, nodesCount)
+
+	for _, n := range nodesCopy {
+		wg.Add(1)
+		go func(node Node) {
+			defer wg.Done()
+
+			// Clone input to prevent data races
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			res, err := node.Process(inputCopy)
+			if err == nil {
+				mu.Lock()
+				results = append(results, res)
+				mu.Unlock()
+			}
+		}(n)
+	}
+
+	wg.Wait()
+
+	if len(results) == 0 {
+		return nil, ErrAllNodesFailed
+	}
+
+	// Tally results to find the majority
+	type tally struct {
+		count int
+		data  []byte
+	}
+
+	tallies := make(map[string]*tally)
+	maxCount := 0
+	var consensusData []byte
+
+	for _, res := range results {
+		key := string(res) // string cast works for byte slice hashing in maps
+		if t, ok := tallies[key]; ok {
+			t.count++
+		} else {
+			tallies[key] = &tally{count: 1, data: res}
+		}
+
+		if tallies[key].count > maxCount {
+			maxCount = tallies[key].count
+			consensusData = tallies[key].data
+		}
+	}
+
+	// Check if the most common result achieves a strict majority of all configured nodes
+	if maxCount > nodesCount/2 {
+		return consensusData, nil
+	}
+
+	return nil, ErrNoConsensus
+}

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -10,8 +10,10 @@ import (
 )
 
 var (
-	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
-	ErrProcessTimeout     = errors.New("process timed out")
+	ErrCircuitBreakerOpen      = errors.New("circuit breaker is open")
+	ErrProcessTimeout          = errors.New("process timed out")
+	ErrRateLimitExceeded       = errors.New("rate limit exceeded")
+	ErrConcurrencyLimitReached = errors.New("concurrency limit reached")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +59,55 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimitMiddleware restricts the number of requests processed per second
+// using a simple token bucket algorithm.
+func RateLimitMiddleware(requestsPerSecond int) Middleware {
+	if requestsPerSecond <= 0 {
+		panic("RateLimitMiddleware requires requestsPerSecond > 0")
+	}
+
+	interval := time.Second / time.Duration(requestsPerSecond)
+
+	// Create a channel that will receive a token every 'interval'
+	ticker := time.NewTicker(interval)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			select {
+			case <-ticker.C:
+				return next(input)
+			default:
+				// If we can't get a token immediately, the rate limit is exceeded
+				return nil, ErrRateLimitExceeded
+			}
+		}
+	}
+}
+
+// ConcurrencyLimitMiddleware limits the maximum number of simultaneous
+// Process executions allowed for a node.
+func ConcurrencyLimitMiddleware(maxConcurrent int) Middleware {
+	if maxConcurrent <= 0 {
+		panic("ConcurrencyLimitMiddleware requires maxConcurrent > 0")
+	}
+
+	// Use a buffered channel as a semaphore
+	semaphore := make(chan struct{}, maxConcurrent)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			select {
+			case semaphore <- struct{}{}:
+				// Acquired a slot, make sure to release it when done
+				defer func() { <-semaphore }()
+				return next(input)
+			default:
+				return nil, ErrConcurrencyLimitReached
+			}
 		}
 	}
 }

--- a/node/tests/consensus_node_test.go
+++ b/node/tests/consensus_node_test.go
@@ -1,0 +1,150 @@
+package node_test
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestConsensusNode_Process_Success(t *testing.T) {
+	cn := node.NewConsensusNode("consensus1")
+	defer cleanupNodes(t, []node.Node{cn})
+
+	node1 := node.NewBaseNode("node1")
+	node1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+	node2 := node.NewBaseNode("node2")
+	node2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+	node3 := node.NewBaseNode("node3")
+	node3.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+
+	cn.AddNode(node1)
+	cn.AddNode(node2)
+	cn.AddNode(node3)
+
+	result, err := cn.Process([]byte("test"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(result, []byte("A")) {
+		t.Fatalf("expected result 'A', got %s", result)
+	}
+}
+
+func TestConsensusNode_Process_NoConsensus(t *testing.T) {
+	cn := node.NewConsensusNode("consensus1")
+	defer cleanupNodes(t, []node.Node{cn})
+
+	node1 := node.NewBaseNode("node1")
+	node1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+	node2 := node.NewBaseNode("node2")
+	node2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+	node3 := node.NewBaseNode("node3")
+	node3.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("C"), nil
+	})
+
+	cn.AddNode(node1)
+	cn.AddNode(node2)
+	cn.AddNode(node3)
+
+	_, err := cn.Process([]byte("test"))
+	if !errors.Is(err, node.ErrNoConsensus) {
+		t.Fatalf("expected ErrNoConsensus, got %v", err)
+	}
+}
+
+func TestConsensusNode_Process_AllNodesFailed(t *testing.T) {
+	cn := node.NewConsensusNode("consensus1")
+	defer cleanupNodes(t, []node.Node{cn})
+
+	node1 := node.NewBaseNode("node1")
+	node1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("error A")
+	})
+	node2 := node.NewBaseNode("node2")
+	node2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("error B")
+	})
+
+	cn.AddNode(node1)
+	cn.AddNode(node2)
+
+	_, err := cn.Process([]byte("test"))
+	if !errors.Is(err, node.ErrAllNodesFailed) {
+		t.Fatalf("expected ErrAllNodesFailed, got %v", err)
+	}
+}
+
+func TestConsensusNode_Process_NoNodes(t *testing.T) {
+	cn := node.NewConsensusNode("consensus1")
+	defer cleanupNodes(t, []node.Node{cn})
+
+	_, err := cn.Process([]byte("test"))
+	if !errors.Is(err, node.ErrNoNodes) {
+		t.Fatalf("expected ErrNoNodes, got %v", err)
+	}
+}
+
+func TestConsensusNode_RemoveNode(t *testing.T) {
+	cn := node.NewConsensusNode("consensus1")
+	defer cleanupNodes(t, []node.Node{cn})
+
+	node1 := node.NewBaseNode("node1")
+	cn.AddNode(node1)
+
+	if len(cn.GetNodes()) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(cn.GetNodes()))
+	}
+
+	cn.RemoveNode("node1")
+
+	if len(cn.GetNodes()) != 0 {
+		t.Fatalf("expected 0 nodes after removal, got %d", len(cn.GetNodes()))
+	}
+}
+
+func TestConsensusNode_TimeoutGracefully(t *testing.T) {
+	cn := node.NewConsensusNode("consensus1")
+	defer cleanupNodes(t, []node.Node{cn})
+
+	node1 := node.NewBaseNode("node1")
+	node1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+	node2 := node.NewBaseNode("node2")
+	node2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(50 * time.Millisecond) // Simulating slow processing
+		return []byte("B"), nil
+	})
+	node3 := node.NewBaseNode("node3")
+	node3.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+
+	cn.AddNode(node1)
+	cn.AddNode(node2)
+	cn.AddNode(node3)
+
+	result, err := cn.Process([]byte("test"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !reflect.DeepEqual(result, []byte("A")) {
+		t.Fatalf("expected result 'A', got %s", result)
+	}
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -3,6 +3,7 @@ package node_test
 import (
 	"errors"
 	"github.com/lhemerly/Constellation/node"
+	"sync"
 	"testing"
 	"time"
 )
@@ -313,4 +314,112 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 	if !errors.Is(err, node.ErrCircuitBreakerOpen) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
 	}
+}
+
+func TestRateLimitMiddleware(t *testing.T) {
+	n := node.NewBaseNode("test-rate-limit")
+	defer cleanupNodes(t, []node.Node{n})
+
+	processCount := 0
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		processCount++
+		return input, nil
+	})
+
+	// Set a very low rate limit for testing
+	n.Use(node.RateLimitMiddleware(10))
+
+	// The first request will probably fail because the ticker hasn't fired yet
+	// Let's wait a bit to guarantee we have a token
+	time.Sleep(150 * time.Millisecond)
+
+	_, err := n.Process([]byte("test"))
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	// Immediate next request should fail
+	_, err = n.Process([]byte("test"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("Expected ErrRateLimitExceeded, got: %v", err)
+	}
+}
+
+func TestRateLimitMiddleware_PanicOnInvalidConfig(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic for invalid config, but none occurred")
+		}
+	}()
+
+	node.RateLimitMiddleware(0)
+}
+
+func TestConcurrencyLimitMiddleware(t *testing.T) {
+	n := node.NewBaseNode("test-concurrency-limit")
+	defer cleanupNodes(t, []node.Node{n})
+
+	var wg sync.WaitGroup
+	readyChan := make(chan struct{})
+	unblockChan := make(chan struct{})
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		// Signal that we are processing
+		readyChan <- struct{}{}
+		// Wait until we are unblocked
+		<-unblockChan
+		return input, nil
+	})
+
+	n.Use(node.ConcurrencyLimitMiddleware(1))
+
+	// Start the first process, which should succeed and block
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := n.Process([]byte("test"))
+		if err != nil {
+			t.Errorf("Expected no error for first process, got: %v", err)
+		}
+	}()
+
+	// Wait for the first process to actually enter the processing function
+	<-readyChan
+
+	// Try a second process concurrently. It should hit the concurrency limit
+	_, err := n.Process([]byte("test2"))
+	if !errors.Is(err, node.ErrConcurrencyLimitReached) {
+		t.Fatalf("Expected ErrConcurrencyLimitReached, got: %v", err)
+	}
+
+	// Unblock the first process and wait for it to finish
+	unblockChan <- struct{}{}
+	wg.Wait()
+
+	// Now a new process should succeed because the semaphore was released
+	// We need another goroutine or run asynchronously because the process function will block again
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := n.Process([]byte("test3"))
+		if err != nil {
+			t.Errorf("Expected no error for third process, got: %v", err)
+		}
+	}()
+
+	// Wait for the third process to enter the processing function
+	<-readyChan
+	// Unblock it
+	unblockChan <- struct{}{}
+	wg.Wait()
+}
+
+func TestConcurrencyLimitMiddleware_PanicOnInvalidConfig(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic for invalid config, but none occurred")
+		}
+	}()
+
+	node.ConcurrencyLimitMiddleware(0)
 }


### PR DESCRIPTION
This PR introduces powerful additions to the node package, focusing on fault tolerance and traffic control.

*   **ConsensusNode:** Added `node/consensus_node.go`, which distributes input payloads to a set of participating sub-nodes. It tallies the returned byte slices and requires a strict majority (`> N/2`) to produce a final consensus output. If a majority is not reached, it correctly falls back to `ErrNoConsensus`.
*   **RateLimitMiddleware:** Added a token-bucket rate limiter to `node/middlewares.go`. It effectively restricts requests-per-second, providing immediate shedding (`ErrRateLimitExceeded`) when the limit is breached.
*   **ConcurrencyLimitMiddleware:** Added a semaphore-based concurrency limiter to `node/middlewares.go`. This acts as a circuit breaker against goroutine exhaustion during execution spikes, returning `ErrConcurrencyLimitReached` when the active pool is full.

Tested comprehensively via added unit tests in `node/tests/consensus_node_test.go` and `node/tests/middlewares_test.go`. The entire repository test suite passes with zero regressions.

---
*PR created automatically by Jules for task [15680366405208040024](https://jules.google.com/task/15680366405208040024) started by @lhemerly*