### PR TITLE
docs: update grpc connection example with insecure credentials

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,8 @@ import (
     "fmt"
     "log"
     "github.com/lhemerly/Constellation/connection"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -155,7 +157,7 @@ func main() {
     ctx := context.Background()
 
     // Create a new gRPC connection
-    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to create connection: %v", err)
     }


### PR DESCRIPTION
This PR updates the `readme.md` connection example to include the `grpc.WithTransportCredentials(insecure.NewCredentials())` option when establishing an insecure gRPC connection, which fixes "no transport security set" execution errors.

It also required adding the `google.golang.org/grpc` and `google.golang.org/grpc/credentials/insecure` package imports to the code block.

No other discrepancies were found between the readme and the codebase. Mentions of `RateLimitMiddleware`, `ConcurrencyLimitMiddleware` and `ConsensusNode` were verified to NOT exist in the README.

---
*PR created automatically by Jules for task [13336648895205901510](https://jules.google.com/task/13336648895205901510) started by @lhemerly*