### PR TITLE
⚡ Bolt: [performance improvement] Optimize CacheMiddleware key generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2024-05-18 - Optimize Lock Contention in Notify Method
 **Learning:** Holding a read lock (`RLock()`) for the entire duration of iterating over a map and spawning long-running or blocking goroutines (`wg.Wait()`) creates massive lock contention and opens the door for deadlocks. If any of the spawned workers attempt to acquire a write lock (`Lock()`) on the same mutex (e.g., trying to subscribe or unsubscribe), it will deadlock because the read lock is still held by the waiting parent.
 **Action:** Always copy map/slice contents to a local slice under the lock, then immediately release the lock before iterating and processing the items concurrently. Apply this specifically when dealing with publisher/subscriber patterns in the codebase to keep the hot path lock-free.
+
+## 2024-06-05 - Direct Array Comparison for SHA256 Keys
+**Learning:** `sha256.Sum256(input)` generates a `[32]byte` array directly, and in Go, arrays of comparable types are themselves comparable and can be used directly as map keys. Replacing `sha256.New()`, `Write()`, `Sum(nil)` and `hex.EncodeToString` with a single `Sum256` call and using the array as the map key eliminates multiple string and slice allocations, significantly reducing GC pressure.
+**Action:** When implementing caching or hashing keys for high-throughput operations in Go, avoid hex-encoding if the key is only used internally in a map. Use `sha256.Sum256` and the resulting `[32]byte` array directly.

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"log"
 	"sync"
@@ -70,14 +69,15 @@ func CacheMiddleware(ttl time.Duration) Middleware {
 
 	var (
 		mu    sync.RWMutex
-		cache = make(map[string]cacheEntry)
+		cache = make(map[[32]byte]cacheEntry)
 	)
 
 	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
 		return func(input []byte) ([]byte, error) {
-			hasher := sha256.New()
-			hasher.Write(input)
-			key := hex.EncodeToString(hasher.Sum(nil))
+			// sha256.Sum256 generates a [32]byte array directly.
+			// Using this array as a map key instead of hex-encoding to a string
+			// eliminates multiple string/slice allocations and reduces GC pressure.
+			key := sha256.Sum256(input)
 
 			mu.RLock()
 			entry, exists := cache[key]


### PR DESCRIPTION
💡 **What:** Optimized the `CacheMiddleware` to use `sha256.Sum256(input)` directly and changed the cache map key from `string` to a `[32]byte` array.
🎯 **Why:** The previous implementation used `sha256.New()`, `.Write()`, and `.Sum()`, followed by `hex.EncodeToString()`. This created multiple heap allocations per request (hash state, sum slice, hex string). By using the array directly, we eliminate these allocations and reduce GC pressure.
📊 **Impact:** Significantly reduces memory allocations per cached process operation and speeds up the cache key generation step. Benchmarks confirm a single small allocation per operation instead of multiple.
🔬 **Measurement:** Verify with `go test -bench=BenchmarkCacheMiddleware -benchmem ./node/tests/` to see reduced `allocs/op` and `B/op`.

---
*PR created automatically by Jules for task [10259024959039612400](https://jules.google.com/task/10259024959039612400) started by @lhemerly*