### PR TITLE
docs: fix file references in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
Updates `readme.md` to fix missing/incorrect file references. The readme incorrectly referenced `CONTRIBUTING.md` and `LICENSE`, which have been updated to `CONTRIBUTE.md` and `LICENSE.md` respectively, to align with the actual files present in the repository. This satisfies the request to check the codebase against the readme and report any discrepancies. No missing functionality was documented in the readme that is missing in the codebase.

---
*PR created automatically by Jules for task [11753359043157536160](https://jules.google.com/task/11753359043157536160) started by @lhemerly*