### PR TITLE
docs: fix README.md inaccuracies in connection example and file paths

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,8 @@ import (
     "fmt"
     "log"
     "github.com/lhemerly/Constellation/connection"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -155,7 +157,7 @@ func main() {
     ctx := context.Background()
 
     // Create a new gRPC connection
-    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to create connection: %v", err)
     }
@@ -198,8 +200,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
Fixes inaccuracies found in `readme.md`:
1. The `connection` package usage example for gRPC requires explicit transport credentials in recent gRPC versions. Added the required option and imports.
2. The reference to the contributing guidelines was pointing to `CONTRIBUTING.md`, changed to the actual `CONTRIBUTE.md`.
3. The reference to the license was missing its extension, changed to `LICENSE.md`.

No missing features/functionality were found when comparing the Readme to the codebase. All listed node types, middlewares, and connection implementations are present in the code.

---
*PR created automatically by Jules for task [10527951670121084861](https://jules.google.com/task/10527951670121084861) started by @lhemerly*