### PR TITLE
docs: update file references in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
Updated the references to `CONTRIBUTING.md` and `LICENSE` in the `readme.md` to point to the correct files `CONTRIBUTE.md` and `LICENSE.md`.

---
*PR created automatically by Jules for task [9753442281406519302](https://jules.google.com/task/9753442281406519302) started by @lhemerly*