### PR TITLE
feat(node): add RateLimitMiddleware

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -213,3 +213,36 @@ func CircuitBreakerMiddleware(maxFailures int, cooldown time.Duration) Middlewar
 		}
 	}
 }
+
+// ErrRateLimitExceeded is returned when the rate limit for a node is exceeded.
+var ErrRateLimitExceeded = errors.New("rate limit exceeded")
+
+// RateLimitMiddleware limits the rate of processing requests based on a token bucket algorithm.
+// rate is the number of tokens added per second.
+// capacity is the maximum number of tokens the bucket can hold.
+func RateLimitMiddleware(rate float64, capacity int) Middleware {
+	var mu sync.Mutex
+	tokens := float64(capacity)
+	lastRefill := time.Now()
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+			now := time.Now()
+			elapsed := now.Sub(lastRefill).Seconds()
+			tokens += elapsed * rate
+			if tokens > float64(capacity) {
+				tokens = float64(capacity)
+			}
+			lastRefill = now
+
+			if tokens >= 1 {
+				tokens -= 1
+				mu.Unlock()
+				return next(input)
+			}
+			mu.Unlock()
+			return nil, ErrRateLimitExceeded
+		}
+	}
+}

--- a/node/tests/rate_limit_test.go
+++ b/node/tests/rate_limit_test.go
@@ -1,0 +1,47 @@
+package node_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestMiddlewares_RateLimit(t *testing.T) {
+	n := node.NewBaseNode("rate-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	n.Use(node.RateLimitMiddleware(10.0, 2)) // 10 tokens/sec, max 2 tokens
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return input, nil
+	})
+
+	// 1st request should succeed
+	_, err := n.Process([]byte("1"))
+	if err != nil {
+		t.Errorf("Expected success, got %v", err)
+	}
+
+	// 2nd request should succeed
+	_, err = n.Process([]byte("2"))
+	if err != nil {
+		t.Errorf("Expected success, got %v", err)
+	}
+
+	// 3rd request should fail (rate limit exceeded)
+	_, err = n.Process([]byte("3"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Errorf("Expected rate limit error, got %v", err)
+	}
+
+	// Wait for refill (> 1 token, ~100ms)
+	time.Sleep(150 * time.Millisecond)
+
+	// 4th request should succeed
+	_, err = n.Process([]byte("4"))
+	if err != nil {
+		t.Errorf("Expected success after wait, got %v", err)
+	}
+}


### PR DESCRIPTION
Added a new feature: `RateLimitMiddleware` in the `node` package. It uses a token bucket algorithm to rate limit requests, which is highly useful in data processing nodes to prevent overwhelming the systems. Includes tests to verify proper limiting and token refilling behavior.

---
*PR created automatically by Jules for task [17176861994198094934](https://jules.google.com/task/17176861994198094934) started by @lhemerly*