### PR TITLE
docs: fix incorrect file references in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
This PR corrects the file references in `readme.md`.
- `CONTRIBUTING.md` was corrected to `CONTRIBUTE.md`
- `LICENSE` was corrected to `LICENSE.md`

All features documented in the readme have been verified to exist in the current codebase.

---
*PR created automatically by Jules for task [13404323451566373454](https://jules.google.com/task/13404323451566373454) started by @lhemerly*