### PR TITLE
feat: add BroadcastNode, EventStore, and RateLimitMiddleware

### DIFF
--- a/event/event_store.go
+++ b/event/event_store.go
@@ -1,0 +1,68 @@
+package event
+
+import (
+	"sync"
+)
+
+// EventStore defines the interface for storing and retrieving dispatched events.
+type EventStore interface {
+	// Store saves an event.
+	Store(event Event) error
+
+	// GetEvents retrieves all stored events of a specific type.
+	// If eventType is empty, it returns all events.
+	GetEvents(eventType string) ([]Event, error)
+
+	// Clear removes all stored events.
+	Clear() error
+}
+
+// InMemoryEventStore is a simple thread-safe, in-memory implementation of EventStore.
+type InMemoryEventStore struct {
+	mu     sync.RWMutex
+	events []Event
+}
+
+// NewInMemoryEventStore creates a new InMemoryEventStore.
+func NewInMemoryEventStore() *InMemoryEventStore {
+	return &InMemoryEventStore{
+		events: make([]Event, 0),
+	}
+}
+
+// Store saves an event.
+func (s *InMemoryEventStore) Store(event Event) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, event)
+	return nil
+}
+
+// GetEvents retrieves all stored events of a specific type.
+// If eventType is empty, it returns all events.
+func (s *InMemoryEventStore) GetEvents(eventType string) ([]Event, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if eventType == "" {
+		eventsCopy := make([]Event, len(s.events))
+		copy(eventsCopy, s.events)
+		return eventsCopy, nil
+	}
+
+	var filtered []Event
+	for _, e := range s.events {
+		if e.GetType() == eventType {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered, nil
+}
+
+// Clear removes all stored events.
+func (s *InMemoryEventStore) Clear() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = make([]Event, 0)
+	return nil
+}

--- a/event/tests/event_store_test.go
+++ b/event/tests/event_store_test.go
@@ -1,0 +1,59 @@
+package event_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lhemerly/Constellation/event"
+)
+
+func TestInMemoryEventStore(t *testing.T) {
+	store := event.NewInMemoryEventStore()
+
+	e1 := event.NewBaseEvent("typeA", []byte("data1"))
+	e2 := event.NewBaseEvent("typeB", []byte("data2"))
+	e3 := event.NewBaseEvent("typeA", []byte("data3"))
+
+	if err := store.Store(e1); err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+	if err := store.Store(e2); err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+	if err := store.Store(e3); err != nil {
+		t.Fatalf("Store() error = %v", err)
+	}
+
+	// Test GetEvents without filter
+	allEvents, err := store.GetEvents("")
+	if err != nil {
+		t.Fatalf("GetEvents() error = %v", err)
+	}
+	if len(allEvents) != 3 {
+		t.Errorf("GetEvents() returned %d events, want 3", len(allEvents))
+	}
+
+	// Test GetEvents with filter
+	typeAEvents, err := store.GetEvents("typeA")
+	if err != nil {
+		t.Fatalf("GetEvents() error = %v", err)
+	}
+	if len(typeAEvents) != 2 {
+		t.Errorf("GetEvents() returned %d events, want 2", len(typeAEvents))
+	}
+	if !bytes.Equal(typeAEvents[0].GetData(), []byte("data1")) {
+		t.Errorf("Event data mismatch: got %v, want data1", string(typeAEvents[0].GetData()))
+	}
+	if !bytes.Equal(typeAEvents[1].GetData(), []byte("data3")) {
+		t.Errorf("Event data mismatch: got %v, want data3", string(typeAEvents[1].GetData()))
+	}
+
+	// Test Clear
+	if err := store.Clear(); err != nil {
+		t.Fatalf("Clear() error = %v", err)
+	}
+	allEvents, _ = store.GetEvents("")
+	if len(allEvents) != 0 {
+		t.Errorf("GetEvents() returned %d events after clear, want 0", len(allEvents))
+	}
+}

--- a/node/broadcast_node.go
+++ b/node/broadcast_node.go
@@ -1,0 +1,98 @@
+package node
+
+import (
+	"errors"
+	"sync"
+)
+
+// ErrNoBroadcastNodes is returned when the BroadcastNode has no destinations.
+var ErrNoBroadcastNodes = errors.New("no destination nodes available for broadcast")
+
+// BroadcastNode extends BaseNode to distribute incoming requests across
+// multiple destination nodes concurrently and collects their responses.
+type BroadcastNode struct {
+	*BaseNode
+	nodesMutex sync.RWMutex
+	nodes      []Node
+}
+
+// NewBroadcastNode creates a new BroadcastNode with the given ID.
+func NewBroadcastNode(id string) *BroadcastNode {
+	b := &BroadcastNode{
+		BaseNode: NewBaseNode(id),
+		nodes:    make([]Node, 0),
+	}
+
+	b.SetProcessFunc(b.broadcast)
+	return b
+}
+
+// AddNode adds a destination node to the broadcast pool.
+func (b *BroadcastNode) AddNode(node Node) {
+	b.nodesMutex.Lock()
+	defer b.nodesMutex.Unlock()
+	b.nodes = append(b.nodes, node)
+}
+
+// GetNodes returns the current list of destination nodes.
+func (b *BroadcastNode) GetNodes() []Node {
+	b.nodesMutex.RLock()
+	defer b.nodesMutex.RUnlock()
+
+	nodesCopy := make([]Node, len(b.nodes))
+	copy(nodesCopy, b.nodes)
+	return nodesCopy
+}
+
+// broadcast distributes the input data to all destination nodes concurrently.
+func (b *BroadcastNode) broadcast(input []byte) ([]byte, error) {
+	b.nodesMutex.RLock()
+	nodesCount := len(b.nodes)
+
+	if nodesCount == 0 {
+		b.nodesMutex.RUnlock()
+		return nil, ErrNoBroadcastNodes
+	}
+
+	nodesCopy := make([]Node, nodesCount)
+	copy(nodesCopy, b.nodes)
+	b.nodesMutex.RUnlock()
+
+	var wg sync.WaitGroup
+	errs := make([]error, nodesCount)
+	results := make([][]byte, nodesCount)
+
+	for i, node := range nodesCopy {
+		wg.Add(1)
+		go func(idx int, n Node) {
+			defer wg.Done()
+
+			// Clone input to avoid race conditions if a node modifies it
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			res, err := n.Process(inputCopy)
+			errs[idx] = err
+			results[idx] = res
+		}(i, node)
+	}
+
+	wg.Wait()
+
+	var collectedErrs []error
+	var finalOutput []byte
+
+	for i := 0; i < nodesCount; i++ {
+		if errs[i] != nil {
+			collectedErrs = append(collectedErrs, errs[i])
+		} else {
+			finalOutput = append(finalOutput, results[i]...)
+		}
+	}
+
+	if len(collectedErrs) > 0 {
+		return finalOutput, errors.Join(append([]error{errors.New("broadcast partial failure")}, collectedErrs...)...)
+	}
+
+	return finalOutput, nil
+}

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +58,45 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimitMiddleware limits the number of requests per second.
+// It uses a simple token bucket algorithm.
+func RateLimitMiddleware(requestsPerSecond int, burst int) Middleware {
+	// If requestsPerSecond is very high, tokensToAdd will be huge but bounded by burst.
+	// For better precision with small intervals, we could use floating point tokens or
+	// keep track of the remainder.
+	tokens := float64(burst)
+	var mu sync.Mutex
+	lastUpdate := time.Now()
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+
+			now := time.Now()
+			elapsed := now.Sub(lastUpdate)
+
+			// Refill tokens
+			tokensToAdd := elapsed.Seconds() * float64(requestsPerSecond)
+			if tokensToAdd > 0 {
+				tokens += tokensToAdd
+				if tokens > float64(burst) {
+					tokens = float64(burst)
+				}
+				lastUpdate = now
+			}
+
+			if tokens >= 1.0 {
+				tokens -= 1.0
+				mu.Unlock()
+				return next(input)
+			}
+
+			mu.Unlock()
+			return nil, ErrRateLimitExceeded
 		}
 	}
 }

--- a/node/tests/broadcast_node_test.go
+++ b/node/tests/broadcast_node_test.go
@@ -1,0 +1,96 @@
+package node_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestBroadcastNode_Success(t *testing.T) {
+	bn := node.NewBroadcastNode("broadcast-node")
+	if err := bn.Create(); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append(input, []byte("-n1")...), nil
+	})
+
+	n2 := node.NewBaseNode("n2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append(input, []byte("-n2")...), nil
+	})
+
+	bn.AddNode(n1)
+	bn.AddNode(n2)
+
+	defer cleanupNodes(t, []node.Node{bn, n1, n2})
+
+	input := []byte("data")
+	output, err := bn.Process(input)
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+
+	// Output is concatenated. Since order is deterministic via indexing, it should be n1 then n2.
+	expected := []byte("data-n1data-n2")
+	if !bytes.Equal(output, expected) {
+		t.Errorf("Process() output = %s, want %s", string(output), string(expected))
+	}
+}
+
+func TestBroadcastNode_PartialFailure(t *testing.T) {
+	bn := node.NewBroadcastNode("broadcast-node")
+	if err := bn.Create(); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append(input, []byte("-n1")...), nil
+	})
+
+	n2 := node.NewBaseNode("n2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("n2 failed")
+	})
+
+	bn.AddNode(n1)
+	bn.AddNode(n2)
+
+	defer cleanupNodes(t, []node.Node{bn, n1, n2})
+
+	input := []byte("data")
+	output, err := bn.Process(input)
+	if err == nil {
+		t.Fatalf("Process() expected error but got none")
+	}
+
+	if !strings.Contains(err.Error(), "broadcast partial failure") {
+		t.Errorf("Process() error = %v, expected partial failure", err)
+	}
+
+	if !strings.Contains(err.Error(), "n2 failed") {
+		t.Errorf("Process() error = %v, expected n2 failed", err)
+	}
+
+	// It should still return the successful result from n1
+	expected := []byte("data-n1")
+	if !bytes.Equal(output, expected) {
+		t.Errorf("Process() output = %s, want %s", string(output), string(expected))
+	}
+}
+
+func TestBroadcastNode_NoNodes(t *testing.T) {
+	bn := node.NewBroadcastNode("broadcast-node")
+	defer bn.Delete()
+
+	_, err := bn.Process([]byte("data"))
+	if err != node.ErrNoBroadcastNodes {
+		t.Errorf("Expected ErrNoBroadcastNodes, got %v", err)
+	}
+}

--- a/node/tests/middleware_test.go
+++ b/node/tests/middleware_test.go
@@ -99,3 +99,34 @@ func TestBaseNodeMiddleware(t *testing.T) {
 		t.Errorf("Process() output = %v, want %v", string(output), string(expected2))
 	}
 }
+
+func TestRateLimitMiddleware(t *testing.T) {
+	n := node.NewBaseNode("node-ratelimit-test")
+	if err := n.Create(); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	defer n.Delete()
+
+	// 10 requests per second, burst of 2
+	n.Use(node.RateLimitMiddleware(10, 2))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return input, nil
+	})
+
+	input := []byte("data")
+
+	// The burst is 2, so the first 2 requests should succeed.
+	for i := 0; i < 2; i++ {
+		_, err := n.Process(input)
+		if err != nil {
+			t.Fatalf("Request %d: expected success, got %v", i+1, err)
+		}
+	}
+
+	// The 3rd request should fail with ErrRateLimitExceeded since we haven't waited for tokens to refill.
+	_, err := n.Process(input)
+	if err != node.ErrRateLimitExceeded {
+		t.Fatalf("Request 3: expected ErrRateLimitExceeded, got %v", err)
+	}
+}


### PR DESCRIPTION
Introduced new architectural components as per full creativity mode request:
- `RateLimitMiddleware`: Token-bucket node rate-limiter.
- `BroadcastNode`: Fan-out concurrency node.
- `EventStore`: Simple thread-safe event sourcing primitive.

---
*PR created automatically by Jules for task [5360798435290066711](https://jules.google.com/task/5360798435290066711) started by @lhemerly*