### PR TITLE
Update readme to fix typos and gRPC usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,10 @@ import (
     "context"
     "fmt"
     "log"
+
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
+
     "github.com/lhemerly/Constellation/connection"
 )
 
@@ -155,7 +159,7 @@ func main() {
     ctx := context.Background()
 
     // Create a new gRPC connection
-    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to create connection: %v", err)
     }
@@ -198,7 +202,7 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 


### PR DESCRIPTION
Update `readme.md` to reflect the actual state of the project.

Changes:
- Corrected contributing document link.
- Modernized gRPC dialing in the code example to use `grpc.WithTransportCredentials(insecure.NewCredentials())` instead of the old deprecated `grpc.WithInsecure()` default.

Also verified that all features documented in the readme (nodes, middlewares, etc.) are indeed present in the codebase.

---
*PR created automatically by Jules for task [982173132880111205](https://jules.google.com/task/982173132880111205) started by @lhemerly*