### PR TITLE
docs: fix typo in file references in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
This PR fixes typographical errors in the README file, updating references from `CONTRIBUTING.md` to `CONTRIBUTE.md` and `LICENSE` to `LICENSE.md` to accurately reflect the filenames in the repository.

---
*PR created automatically by Jules for task [10218325206491077187](https://jules.google.com/task/10218325206491077187) started by @lhemerly*