### PR TITLE
docs: update file references in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
This PR updates the references in `readme.md` to `CONTRIBUTE.md` and `LICENSE.md`, fixing broken references to files that don't exist under those names.

---
*PR created automatically by Jules for task [6036757486694058206](https://jules.google.com/task/6036757486694058206) started by @lhemerly*