### PR TITLE
⚡ Bolt: [performance improvement] Optimize CacheMiddleware hashing

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2024-05-18 - Optimize Lock Contention in Notify Method
 **Learning:** Holding a read lock (`RLock()`) for the entire duration of iterating over a map and spawning long-running or blocking goroutines (`wg.Wait()`) creates massive lock contention and opens the door for deadlocks. If any of the spawned workers attempt to acquire a write lock (`Lock()`) on the same mutex (e.g., trying to subscribe or unsubscribe), it will deadlock because the read lock is still held by the waiting parent.
 **Action:** Always copy map/slice contents to a local slice under the lock, then immediately release the lock before iterating and processing the items concurrently. Apply this specifically when dealing with publisher/subscriber patterns in the codebase to keep the hot path lock-free.
+## 2026-05-21 - Optimize CacheMiddleware Hash Generation
+**Learning:** Using `sha256.New()` + `Write` + `Sum` and `hex.EncodeToString` creates significant allocation overhead in hot paths (like CacheMiddleware caching). Benchmarks showed an improvement from ~861ns/op and 296 B/op (5 allocs) down to ~465ns/op and 8 B/op (1 alloc).
+**Action:** Use `sha256.Sum256(input)` and utilize the resulting `[32]byte` array directly as a map key whenever generating sha256 cache keys to eliminate memory reallocations and speed up processing.

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"log"
 	"sync"
@@ -69,15 +68,15 @@ func CacheMiddleware(ttl time.Duration) Middleware {
 	}
 
 	var (
-		mu    sync.RWMutex
-		cache = make(map[string]cacheEntry)
+		mu sync.RWMutex
+		// Optimized: using [32]byte directly as cache key to eliminate hex.EncodeToString allocation overhead
+		cache = make(map[[32]byte]cacheEntry)
 	)
 
 	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
 		return func(input []byte) ([]byte, error) {
-			hasher := sha256.New()
-			hasher.Write(input)
-			key := hex.EncodeToString(hasher.Sum(nil))
+			// Optimized: using sha256.Sum256 directly avoids sha256.New() + Write + Sum allocations
+			key := sha256.Sum256(input)
 
 			mu.RLock()
 			entry, exists := cache[key]


### PR DESCRIPTION
**💡 What**:
Replaced the use of `sha256.New()` + `hasher.Write()` + `hex.EncodeToString(hasher.Sum(nil))` in `node/middlewares.go` (`CacheMiddleware`) with a direct call to `sha256.Sum256(input)`. 
Also changed the `cache` map definition to use the resulting `[32]byte` array directly as its key, instead of a `string`.

**🎯 Why**: 
The previous method involved creating a new hasher object, calling multiple methods, and converting the resulting bytes into a hex string for every single cache check. This added considerable CPU overhead and unnecessary memory allocations (specifically, allocating the hex string) right in the hot path of the `CacheMiddleware`.

**📊 Impact**: 
Eliminates memory reallocations inside the cache key generation and cuts execution time almost in half.

**🔬 Measurement**: 
Before optimization:
```
BenchmarkCacheMiddleware-4   	 1396465	       861.1 ns/op	     296 B/op	       5 allocs/op
```
After optimization:
```
BenchmarkCacheMiddleware-4   	 2683779	       465.1 ns/op	       8 B/op	       1 allocs/op
```
The allocations per operation drop from 5 to 1, and the speed increases from ~861 ns/op to ~465 ns/op.

---
*PR created automatically by Jules for task [16855568726670508963](https://jules.google.com/task/16855568726670508963) started by @lhemerly*