### PR TITLE
feat(node): add worker pool and rate limiter nodes

### DIFF
--- a/node/rate_limiter_node.go
+++ b/node/rate_limiter_node.go
@@ -1,0 +1,60 @@
+package node
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	ErrRateLimitExceeded = errors.New("rate limit exceeded")
+)
+
+// RateLimiterNode limits the rate of incoming requests using a token bucket algorithm.
+type RateLimiterNode struct {
+	*BaseNode
+	rate       float64 // tokens per second
+	capacity   float64 // maximum burst size
+	tokens     float64
+	lastUpdate time.Time
+	mu         sync.Mutex
+}
+
+// NewRateLimiterNode creates a new RateLimiterNode.
+// rate is the number of tokens added per second, and capacity is the maximum burst size.
+func NewRateLimiterNode(id string, rate float64, capacity float64) *RateLimiterNode {
+	return &RateLimiterNode{
+		BaseNode:   NewBaseNode(id),
+		rate:       rate,
+		capacity:   capacity,
+		tokens:     capacity, // Start full
+		lastUpdate: time.Now(),
+	}
+}
+
+// Process processes the input if allowed by the rate limiter.
+func (n *RateLimiterNode) Process(input []byte) ([]byte, error) {
+	n.mu.Lock()
+	now := time.Now()
+	elapsed := now.Sub(n.lastUpdate).Seconds()
+
+	// Replenish tokens based on elapsed time
+	n.tokens += elapsed * n.rate
+	if n.tokens > n.capacity {
+		n.tokens = n.capacity
+	}
+	n.lastUpdate = now
+
+	// Check if we have enough tokens to process
+	if n.tokens < 1.0 {
+		n.mu.Unlock()
+		return nil, ErrRateLimitExceeded
+	}
+
+	// Consume a token
+	n.tokens -= 1.0
+	n.mu.Unlock()
+
+	// Proceed with standard base node processing
+	return n.BaseNode.Process(input)
+}

--- a/node/tests/rate_limiter_node_test.go
+++ b/node/tests/rate_limiter_node_test.go
@@ -1,0 +1,71 @@
+package node_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestRateLimiterNode_Burst(t *testing.T) {
+	// Rate: 1 token/sec, Burst capacity: 3
+	rl := node.NewRateLimiterNode("rl-node", 1.0, 3.0)
+	err := rl.Create()
+	if err != nil {
+		t.Fatalf("Failed to create RateLimiterNode: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{rl})
+
+	rl.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("processed "), input...), nil
+	})
+
+	// First 3 should pass due to burst capacity
+	for i := 0; i < 3; i++ {
+		res, err := rl.Process([]byte("data"))
+		if err != nil {
+			t.Fatalf("Expected process to succeed on attempt %d, got err: %v", i, err)
+		}
+		if string(res) != "processed data" {
+			t.Errorf("Unexpected output: %s", string(res))
+		}
+	}
+
+	// 4th should fail since capacity is exhausted and time hasn't elapsed
+	_, err = rl.Process([]byte("data"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Errorf("Expected ErrRateLimitExceeded, got %v", err)
+	}
+}
+
+func TestRateLimiterNode_Replenish(t *testing.T) {
+	// Rate: 10 tokens/sec, Burst capacity: 1
+	rl := node.NewRateLimiterNode("rl-node", 10.0, 1.0)
+	err := rl.Create()
+	if err != nil {
+		t.Fatalf("Failed to create RateLimiterNode: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{rl})
+
+	// Exhaust token
+	_, err = rl.Process([]byte("data"))
+	if err != nil {
+		t.Fatalf("Expected initial process to succeed, got %v", err)
+	}
+
+	// Immediate next should fail
+	_, err = rl.Process([]byte("data"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("Expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// Wait enough time to replenish 1 token (rate 10/s = 100ms per token)
+	time.Sleep(150 * time.Millisecond)
+
+	// Should succeed now
+	_, err = rl.Process([]byte("data"))
+	if err != nil {
+		t.Errorf("Expected process to succeed after replenishment, got err: %v", err)
+	}
+}

--- a/node/tests/worker_pool_node_test.go
+++ b/node/tests/worker_pool_node_test.go
@@ -1,0 +1,149 @@
+package node_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestWorkerPoolNode_BasicProcess(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-node", 3)
+	err := wp.Create()
+	if err != nil {
+		t.Fatalf("Failed to create WorkerPoolNode: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{wp})
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("processed "), input...), nil
+	})
+
+	result, err := wp.Process([]byte("data"))
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	if string(result) != "processed data" {
+		t.Errorf("Expected 'processed data', got '%s'", string(result))
+	}
+
+	if wp.GetEventCount() != 1 {
+		t.Errorf("Expected event count 1, got %d", wp.GetEventCount())
+	}
+}
+
+func TestWorkerPoolNode_Concurrency(t *testing.T) {
+	numWorkers := 5
+	wp := node.NewWorkerPoolNode("wp-node", numWorkers)
+	err := wp.Create()
+	if err != nil {
+		t.Fatalf("Failed to create WorkerPoolNode: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{wp})
+
+	// Use a WaitGroup to ensure all workers are blocked initially
+	var startWg sync.WaitGroup
+	startWg.Add(numWorkers)
+	var processWg sync.WaitGroup
+	processWg.Add(numWorkers)
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		startWg.Done()
+		processWg.Wait() // Block until all workers have picked up a job
+		return input, nil
+	})
+
+	var resultWg sync.WaitGroup
+	for i := 0; i < numWorkers; i++ {
+		resultWg.Add(1)
+		go func(idx int) {
+			defer resultWg.Done()
+			_, err := wp.Process([]byte("test"))
+			if err != nil {
+				t.Errorf("Worker %d failed: %v", idx, err)
+			}
+		}(i)
+	}
+
+	// Wait for all workers to start processing
+	startWg.Wait()
+	// Unblock all workers simultaneously
+	processWg.Done()
+	processWg.Done()
+	processWg.Done()
+	processWg.Done()
+	processWg.Done() // Done numWorkers times, could also use channels, but this works
+
+	resultWg.Wait()
+
+	if wp.GetEventCount() != uint64(numWorkers) {
+		t.Errorf("Expected event count %d, got %d", numWorkers, wp.GetEventCount())
+	}
+}
+
+func TestWorkerPoolNode_ProcessWithContextTimeout(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-node", 1)
+	err := wp.Create()
+	if err != nil {
+		t.Fatalf("Failed to create WorkerPoolNode: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{wp})
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond)
+		return input, nil
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err = wp.ProcessWithContext(ctx, []byte("data"))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Expected DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestWorkerPoolNode_Delete(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-node", 2)
+	err := wp.Create()
+	if err != nil {
+		t.Fatalf("Failed to create WorkerPoolNode: %v", err)
+	}
+
+	// Submit a slow job that will keep the worker busy while we delete
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(50 * time.Millisecond)
+		return input, nil
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := wp.Process([]byte("data"))
+		// It might succeed or return ErrWorkerPoolClosed depending on timing
+		if err != nil && !errors.Is(err, node.ErrWorkerPoolClosed) && err.Error() != "worker pool is closed" {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}()
+
+	// Give the goroutine time to submit the job
+	time.Sleep(10 * time.Millisecond)
+
+	err = wp.Delete()
+	if err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+
+	wg.Wait()
+
+	// Try processing after close
+	_, err = wp.Process([]byte("data"))
+	if err == nil || err.Error() != "worker pool is closed" {
+		t.Errorf("Expected worker pool is closed error, got %v", err)
+	}
+}

--- a/node/worker_pool_node.go
+++ b/node/worker_pool_node.go
@@ -1,0 +1,175 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+)
+
+var (
+	ErrWorkerPoolClosed = errors.New("worker pool is closed")
+)
+
+type workerJob struct {
+	input      []byte
+	resultChan chan workerResult
+	ctx        context.Context
+}
+
+type workerResult struct {
+	output []byte
+	err    error
+}
+
+// WorkerPoolNode manages a pool of worker goroutines to process requests concurrently.
+type WorkerPoolNode struct {
+	*BaseNode
+	numWorkers int
+	jobQueue   chan workerJob
+	wg         sync.WaitGroup
+	ctx        context.Context
+	cancel     context.CancelFunc
+	closed     atomic.Bool
+}
+
+// NewWorkerPoolNode creates a new WorkerPoolNode with the specified number of workers.
+func NewWorkerPoolNode(id string, numWorkers int) *WorkerPoolNode {
+	if numWorkers <= 0 {
+		numWorkers = 1
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &WorkerPoolNode{
+		BaseNode:   NewBaseNode(id),
+		numWorkers: numWorkers,
+		// Buffer size could be larger, but setting to numWorkers allows some buffering
+		jobQueue: make(chan workerJob, numWorkers),
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+}
+
+// Create initializes the worker pool and starts the worker goroutines.
+func (n *WorkerPoolNode) Create() error {
+	if err := n.BaseNode.Create(); err != nil {
+		return err
+	}
+
+	for i := 0; i < n.numWorkers; i++ {
+		n.wg.Add(1)
+		go n.workerLoop()
+	}
+
+	return nil
+}
+
+func (n *WorkerPoolNode) workerLoop() {
+	defer n.wg.Done()
+	for {
+		select {
+		case <-n.ctx.Done():
+			return
+		case job, ok := <-n.jobQueue:
+			if !ok {
+				return
+			}
+
+			// Check if job context is already cancelled
+			select {
+			case <-job.ctx.Done():
+				job.resultChan <- workerResult{nil, job.ctx.Err()}
+				continue
+			default:
+			}
+
+			output, err := n.BaseNode.Process(job.input)
+
+			// Try to send result, but respect job context cancellation
+			select {
+			case job.resultChan <- workerResult{output, err}:
+			case <-job.ctx.Done():
+			}
+		}
+	}
+}
+
+// Process submits a job to the worker pool and waits for the result.
+func (n *WorkerPoolNode) Process(input []byte) ([]byte, error) {
+	if n.closed.Load() {
+		return nil, ErrWorkerPoolClosed
+	}
+
+	resultChan := make(chan workerResult, 1)
+	job := workerJob{
+		input:      input,
+		resultChan: resultChan,
+		ctx:        context.Background(),
+	}
+
+	select {
+	case <-n.ctx.Done():
+		return nil, ErrWorkerPoolClosed
+	case n.jobQueue <- job:
+	}
+
+	select {
+	case <-n.ctx.Done():
+		return nil, ErrWorkerPoolClosed
+	case res := <-resultChan:
+		return res.output, res.err
+	}
+}
+
+// ProcessWithContext allows submitting a job with a specific context.
+func (n *WorkerPoolNode) ProcessWithContext(ctx context.Context, input []byte) ([]byte, error) {
+	if n.closed.Load() {
+		return nil, ErrWorkerPoolClosed
+	}
+
+	resultChan := make(chan workerResult, 1)
+	job := workerJob{
+		input:      input,
+		resultChan: resultChan,
+		ctx:        ctx,
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-n.ctx.Done():
+		return nil, ErrWorkerPoolClosed
+	case n.jobQueue <- job:
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-n.ctx.Done():
+		return nil, ErrWorkerPoolClosed
+	case res := <-resultChan:
+		return res.output, res.err
+	}
+}
+
+// Delete stops the worker pool and cleans up resources.
+func (n *WorkerPoolNode) Delete() error {
+	if n.closed.CompareAndSwap(false, true) {
+		n.cancel()
+		n.wg.Wait()
+
+		// Drain pending jobs in queue
+		for {
+			select {
+			case job := <-n.jobQueue:
+				select {
+				case job.resultChan <- workerResult{nil, ErrWorkerPoolClosed}:
+				default:
+				}
+			default:
+				goto drainDone
+			}
+		}
+	drainDone:
+	}
+	return n.BaseNode.Delete()
+}

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ The `node` package provides abstractions for creating and managing nodes within 
 - Data Processing
 - Subscription Management
 - Event Notification
-- **Advanced Node Types**: Includes `FailoverNode` (primary/secondary logic), `LoadBalancerNode` (round-robin distribution), `PipelineNode` (sequential stage processing), `RouterNode` (conditional message routing), and `MapReduceNode` (parallel mappers and a single reducer).
+- **Advanced Node Types**: Includes `FailoverNode` (primary/secondary logic), `LoadBalancerNode` (round-robin distribution), `PipelineNode` (sequential stage processing), `RouterNode` (conditional message routing), `MapReduceNode` (parallel mappers and a single reducer), `WorkerPoolNode` (concurrent worker pool), and `RateLimiterNode` (token bucket rate limiting).
 - **Middlewares**: Supports composing node processing chains with middlewares such as `LoggingMiddleware`, `RetryMiddleware`, `RecoveryMiddleware`, `CacheMiddleware`, `TimeoutMiddleware`, and `CircuitBreakerMiddleware`.
 
 ### 2. Connection Package


### PR DESCRIPTION
Introduces two new advanced node types to the `node` package:
- `WorkerPoolNode`: Uses a fixed pool of goroutines to process requests
concurrently, managing concurrency and context timeouts effectively.
- `RateLimiterNode`: Implements a token bucket algorithm to limit processing
throughput and prevent burst traffic.

Both nodes include thorough test coverage in `node/tests` and are documented
in the `readme.md`.

---
*PR created automatically by Jules for task [4169084569930480806](https://jules.google.com/task/4169084569930480806) started by @lhemerly*