### PR TITLE
docs: fix references to CONTRIBUTING and LICENSE files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
I have reviewed the `readme.md` against the repository to ensure all code functionality described (nodes, connections, events, middlewares) exists and matches the codebase. I did not find any missing code functionality, but I did find and correct two broken file references:
- `CONTRIBUTING.md` was corrected to `CONTRIBUTE.md`
- `LICENSE` was corrected to `LICENSE.md`

Tests pass successfully.

---
*PR created automatically by Jules for task [17037292460769843935](https://jules.google.com/task/17037292460769843935) started by @lhemerly*