### PR TITLE
⚡ Bolt: [performance improvement] Optimize CacheMiddleware key generation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,6 @@
 ## 2024-05-18 - Optimize Lock Contention in Notify Method
 **Learning:** Holding a read lock (`RLock()`) for the entire duration of iterating over a map and spawning long-running or blocking goroutines (`wg.Wait()`) creates massive lock contention and opens the door for deadlocks. If any of the spawned workers attempt to acquire a write lock (`Lock()`) on the same mutex (e.g., trying to subscribe or unsubscribe), it will deadlock because the read lock is still held by the waiting parent.
 **Action:** Always copy map/slice contents to a local slice under the lock, then immediately release the lock before iterating and processing the items concurrently. Apply this specifically when dealing with publisher/subscriber patterns in the codebase to keep the hot path lock-free.
+## 2026-05-24 - Optimize CacheMiddleware Key Generation
+**Learning:** Generating string hash keys via `sha256.New()`, `hasher.Write()`, and `hex.EncodeToString(hasher.Sum(nil))` causes 3 heap memory allocations (~160 B/op) and is about 40% slower than avoiding hex formatting. The resulting string is used as a map key which is sub-optimal compared to a fixed array.
+**Action:** Use `sha256.Sum256(input)` which allocates 0 B/op on the heap. Use the returned `[32]byte` array directly as a map key in Go to completely eliminate hex string allocation overhead for highly-frequent caching paths.

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -2,7 +2,6 @@ package node
 
 import (
 	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"log"
 	"sync"
@@ -70,14 +69,13 @@ func CacheMiddleware(ttl time.Duration) Middleware {
 
 	var (
 		mu    sync.RWMutex
-		cache = make(map[string]cacheEntry)
+		cache = make(map[[32]byte]cacheEntry)
 	)
 
 	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
 		return func(input []byte) ([]byte, error) {
-			hasher := sha256.New()
-			hasher.Write(input)
-			key := hex.EncodeToString(hasher.Sum(nil))
+			// sha256.Sum256 is ~40% faster and prevents hex string allocations (0 allocs vs 3)
+			key := sha256.Sum256(input)
 
 			mu.RLock()
 			entry, exists := cache[key]


### PR DESCRIPTION
💡 **What:**
Optimized the key generation logic inside `CacheMiddleware` in `node/middlewares.go`. The cache map key type was changed from `string` to `[32]byte`, and `sha256.Sum256(input)` is now used instead of `sha256.New()` and `hex.EncodeToString(hasher.Sum(nil))`.

🎯 **Why:**
Using strings and the `hash.Hash` interface for short, frequent hash computations creates significant garbage collection overhead and is slower. Since arrays are comparable in Go, we can map directly against the fixed `[32]byte` return value from `Sum256` to avoid allocations completely.

📊 **Impact:**
- Heap allocations drop from 3 (`~160 B/op`) down to **0 (`0 B/op`)**.
- Execution speed for hashing the input improves by **~40%**.

🔬 **Measurement:**
Running `go test -bench=. -benchmem` confirms the difference between the approaches:

Before:
`BenchmarkHashHex-4       2439608        492.9 ns/op       160 B/op        3 allocs/op`

After:
`BenchmarkHashArray-4     4189633        283.5 ns/op         0 B/op        0 allocs/op`

---
*PR created automatically by Jules for task [14055696298773610679](https://jules.google.com/task/14055696298773610679) started by @lhemerly*