### PR TITLE
feat: add WorkerPoolNode for concurrent request processing

### DIFF
--- a/node/tests/worker_pool_node_test.go
+++ b/node/tests/worker_pool_node_test.go
@@ -1,0 +1,131 @@
+package node_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestWorkerPoolNode_CreateDelete(t *testing.T) {
+	pool := node.NewWorkerPoolNode("pool-1", 2)
+	defer cleanupNodes(t, []node.Node{pool})
+
+	if pool.GetID() != "pool-1" {
+		t.Errorf("expected ID pool-1, got %s", pool.GetID())
+	}
+
+	if err := pool.Create(); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if err := pool.Delete(); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+}
+
+func TestWorkerPoolNode_DeleteTwice(t *testing.T) {
+	pool := node.NewWorkerPoolNode("pool-1", 2)
+	defer cleanupNodes(t, []node.Node{pool})
+
+	if err := pool.Create(); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if err := pool.Delete(); err != nil {
+		t.Fatalf("first Delete() error = %v", err)
+	}
+
+	if err := pool.Delete(); err != nil {
+		t.Fatalf("second Delete() error = %v", err)
+	}
+}
+
+func TestWorkerPoolNode_Process(t *testing.T) {
+	pool := node.NewWorkerPoolNode("pool-1", 2)
+	defer cleanupNodes(t, []node.Node{pool})
+
+	pool.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte(fmt.Sprintf("processed-%s", string(input))), nil
+	})
+
+	if err := pool.Create(); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	result, err := pool.Process([]byte("test"))
+	if err != nil {
+		t.Fatalf("Process() error = %v", err)
+	}
+	if string(result) != "processed-test" {
+		t.Errorf("expected 'processed-test', got '%s'", string(result))
+	}
+}
+
+func TestWorkerPoolNode_ProcessAfterDelete(t *testing.T) {
+	pool := node.NewWorkerPoolNode("pool-1", 2)
+	defer cleanupNodes(t, []node.Node{pool})
+
+	if err := pool.Create(); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if err := pool.Delete(); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	_, err := pool.Process([]byte("test"))
+	if err == nil {
+		t.Fatalf("expected error processing after delete")
+	}
+	if !errors.Is(err, node.ErrWorkerPoolDeleted) {
+		t.Errorf("expected ErrWorkerPoolDeleted, got %v", err)
+	}
+}
+
+func TestWorkerPoolNode_ConcurrentProcessing(t *testing.T) {
+	numWorkers := 3
+	pool := node.NewWorkerPoolNode("pool-1", numWorkers)
+	defer cleanupNodes(t, []node.Node{pool})
+
+	var counter int32
+	pool.SetProcessFunc(func(input []byte) ([]byte, error) {
+		atomic.AddInt32(&counter, 1)
+		time.Sleep(10 * time.Millisecond) // Simulate work
+		return []byte(strings.ToUpper(string(input))), nil
+	})
+
+	if err := pool.Create(); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	numRequests := 10
+	var wg sync.WaitGroup
+	wg.Add(numRequests)
+
+	for i := 0; i < numRequests; i++ {
+		go func(id int) {
+			defer wg.Done()
+			input := fmt.Sprintf("req-%d", id)
+			result, err := pool.Process([]byte(input))
+			if err != nil {
+				t.Errorf("Process() error = %v", err)
+			}
+			expected := strings.ToUpper(input)
+			if string(result) != expected {
+				t.Errorf("expected %s, got %s", expected, string(result))
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	if int(counter) != numRequests {
+		t.Errorf("expected %d processes, got %d", numRequests, counter)
+	}
+}

--- a/node/worker_pool_node.go
+++ b/node/worker_pool_node.go
@@ -1,0 +1,144 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+var (
+	ErrWorkerPoolDeleted = errors.New("worker pool deleted")
+)
+
+type job struct {
+	input      []byte
+	resultChan chan<- workerResult
+}
+
+type workerResult struct {
+	output []byte
+	err    error
+}
+
+// WorkerPoolNode processes requests concurrently using a fixed-size pool of goroutines.
+type WorkerPoolNode struct {
+	*BaseNode
+	numWorkers int
+	jobChan    chan job
+	ctx        context.Context
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
+	mu         sync.RWMutex
+	deleted    bool
+}
+
+// NewWorkerPoolNode creates a new WorkerPoolNode with a given ID and number of workers.
+func NewWorkerPoolNode(id string, numWorkers int) *WorkerPoolNode {
+	if numWorkers <= 0 {
+		numWorkers = 1
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &WorkerPoolNode{
+		BaseNode:   NewBaseNode(id),
+		numWorkers: numWorkers,
+		jobChan:    make(chan job, numWorkers),
+		ctx:        ctx,
+		cancel:     cancel,
+	}
+}
+
+// Create initializes the node and starts the worker pool.
+func (n *WorkerPoolNode) Create() error {
+	if err := n.BaseNode.Create(); err != nil {
+		return err
+	}
+
+	n.wg.Add(n.numWorkers)
+	for i := 0; i < n.numWorkers; i++ {
+		go n.worker()
+	}
+
+	return nil
+}
+
+// worker processes jobs from the job channel.
+func (n *WorkerPoolNode) worker() {
+	defer n.wg.Done()
+	for {
+		select {
+		case <-n.ctx.Done():
+			return
+		case j, ok := <-n.jobChan:
+			if !ok {
+				return
+			}
+			// Use n.BaseNode.Process to apply middlewares, tracking, etc.
+			output, err := n.BaseNode.Process(j.input)
+			j.resultChan <- workerResult{output: output, err: err}
+		}
+	}
+}
+
+// Process handles a request by sending it to the worker pool.
+func (n *WorkerPoolNode) Process(input []byte) ([]byte, error) {
+	n.mu.RLock()
+	if n.deleted {
+		n.mu.RUnlock()
+		return nil, ErrWorkerPoolDeleted
+	}
+	n.mu.RUnlock()
+
+	resultChan := make(chan workerResult, 1)
+
+	// Create the job
+	j := job{
+		input:      input,
+		resultChan: resultChan,
+	}
+
+	// Try to queue the job
+	select {
+	case <-n.ctx.Done():
+		return nil, ErrWorkerPoolDeleted
+	case n.jobChan <- j:
+	}
+
+	// Wait for the result
+	select {
+	case <-n.ctx.Done():
+		return nil, ErrWorkerPoolDeleted
+	case res := <-resultChan:
+		return res.output, res.err
+	}
+}
+
+// Delete gracefully shuts down the worker pool and cleans up resources.
+func (n *WorkerPoolNode) Delete() error {
+	n.mu.Lock()
+	if n.deleted {
+		n.mu.Unlock()
+		return nil
+	}
+	n.deleted = true
+	n.mu.Unlock()
+
+	// Signal workers to stop
+	n.cancel()
+
+	// Wait for all workers to finish their current jobs
+	n.wg.Wait()
+
+	// Drain any pending jobs that were queued but not picked up without closing the channel
+	// to prevent panics from slow writers in Process() that passed the deleted check.
+drainLoop:
+	for {
+		select {
+		case j := <-n.jobChan:
+			j.resultChan <- workerResult{nil, ErrWorkerPoolDeleted}
+		default:
+			break drainLoop
+		}
+	}
+
+	return n.BaseNode.Delete()
+}


### PR DESCRIPTION
I've brainstormed and implemented a new `WorkerPoolNode` to enhance the `Constellation` node processing capabilities. This structural node allows users to specify a fixed number of goroutines, providing a simple way to process inputs concurrently out-of-the-box. It safely integrates into the existing context and lifecycle management of BaseNode. I've also written tests ensuring robust concurrent processing and teardown logic.

---
*PR created automatically by Jules for task [18205141854469585997](https://jules.google.com/task/18205141854469585997) started by @lhemerly*