### PR TITLE
docs: update documentation links in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
Changed the references from `CONTRIBUTING.md` to `CONTRIBUTE.md` and `LICENSE` to `LICENSE.md` in `readme.md` to match the actual files in the repository. Also confirmed that all functionalities listed in the `readme.md` are implemented in the codebase.

---
*PR created automatically by Jules for task [2420769050945576473](https://jules.google.com/task/2420769050945576473) started by @lhemerly*