### PR TITLE
feat: Add BroadcastNode and RateLimitMiddleware

### DIFF
--- a/node/broadcast_node.go
+++ b/node/broadcast_node.go
@@ -1,0 +1,111 @@
+package node
+
+import (
+	"errors"
+	"sync"
+)
+
+// BroadcastNode extends BaseNode to distribute incoming requests to all
+// registered destination nodes concurrently.
+type BroadcastNode struct {
+	*BaseNode
+	nodesMutex sync.RWMutex
+	nodes      []Node
+}
+
+// NewBroadcastNode creates a new BroadcastNode with the given ID.
+func NewBroadcastNode(id string) *BroadcastNode {
+	bn := &BroadcastNode{
+		BaseNode: NewBaseNode(id),
+		nodes:    make([]Node, 0),
+	}
+
+	bn.SetProcessFunc(bn.broadcast)
+	return bn
+}
+
+// AddNode adds a destination node to the broadcast pool.
+func (bn *BroadcastNode) AddNode(node Node) {
+	bn.nodesMutex.Lock()
+	defer bn.nodesMutex.Unlock()
+	bn.nodes = append(bn.nodes, node)
+}
+
+// RemoveNode removes a destination node from the broadcast pool by its ID.
+func (bn *BroadcastNode) RemoveNode(nodeID string) {
+	bn.nodesMutex.Lock()
+	defer bn.nodesMutex.Unlock()
+
+	for i, node := range bn.nodes {
+		if node.GetID() == nodeID {
+			bn.nodes = append(bn.nodes[:i], bn.nodes[i+1:]...)
+			break
+		}
+	}
+}
+
+// GetNodes returns the current list of destination nodes.
+func (bn *BroadcastNode) GetNodes() []Node {
+	bn.nodesMutex.RLock()
+	defer bn.nodesMutex.RUnlock()
+
+	nodesCopy := make([]Node, len(bn.nodes))
+	copy(nodesCopy, bn.nodes)
+	return nodesCopy
+}
+
+// broadcast sends the input data to all nodes concurrently and waits for them.
+func (bn *BroadcastNode) broadcast(input []byte) ([]byte, error) {
+	bn.nodesMutex.RLock()
+	nodesCount := len(bn.nodes)
+	if nodesCount == 0 {
+		bn.nodesMutex.RUnlock()
+		return nil, ErrNoNodes
+	}
+
+	targetNodes := make([]Node, nodesCount)
+	copy(targetNodes, bn.nodes)
+	bn.nodesMutex.RUnlock()
+
+	var wg sync.WaitGroup
+	errs := make([]error, nodesCount)
+	results := make([][]byte, nodesCount)
+
+	wg.Add(nodesCount)
+	for i, targetNode := range targetNodes {
+		go func(idx int, n Node) {
+			defer wg.Done()
+
+			// We must pass a copy of the input since a destination node could modify it
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			output, err := n.Process(inputCopy)
+			errs[idx] = err
+			results[idx] = output
+		}(i, targetNode)
+	}
+
+	wg.Wait()
+
+	// Aggregate errors
+	var finalErr error
+	for _, err := range errs {
+		if err != nil {
+			finalErr = errors.Join(finalErr, err)
+		}
+	}
+
+	// Aggregate output
+	var totalLen int
+	for _, res := range results {
+		totalLen += len(res)
+	}
+
+	finalOutput := make([]byte, 0, totalLen)
+	for _, res := range results {
+		finalOutput = append(finalOutput, res...)
+	}
+
+	return finalOutput, finalErr
+}

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +58,46 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimitMiddleware limits the number of requests allowed within a specific time window.
+func RateLimitMiddleware(limit int, window time.Duration) Middleware {
+	var (
+		mu      sync.Mutex
+		tokens  int       = limit
+		lastRef time.Time = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+
+			now := time.Now()
+			elapsed := now.Sub(lastRef)
+
+			// Refill tokens based on elapsed time and the rate
+			tokensToAdd := int(float64(elapsed) / float64(window) * float64(limit))
+			if tokensToAdd > 0 {
+				tokens += tokensToAdd
+				if tokens > limit {
+					tokens = limit
+				}
+				// Advance lastRef by the exact amount of time corresponding to the tokens added
+				// to avoid losing fractional token accumulation over multiple fast calls.
+				durationPerToken := float64(window) / float64(limit)
+				lastRef = lastRef.Add(time.Duration(float64(tokensToAdd) * durationPerToken))
+			}
+
+			if tokens > 0 {
+				tokens--
+				mu.Unlock()
+				return next(input)
+			}
+
+			mu.Unlock()
+			return nil, ErrRateLimitExceeded
 		}
 	}
 }

--- a/node/tests/broadcast_node_test.go
+++ b/node/tests/broadcast_node_test.go
@@ -1,0 +1,108 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"strings"
+	"testing"
+)
+
+func TestBroadcastNode_Success(t *testing.T) {
+	bn := node.NewBroadcastNode("broadcast-node")
+	defer cleanupNodes(t, []node.Node{bn})
+
+	n1 := node.NewBaseNode("node1")
+	n2 := node.NewBaseNode("node2")
+	n3 := node.NewBaseNode("node3")
+	defer cleanupNodes(t, []node.Node{n1, n2, n3})
+
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+	n3.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("C"), nil
+	})
+
+	bn.AddNode(n1)
+	bn.AddNode(n2)
+	bn.AddNode(n3)
+
+	output, err := bn.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	strOutput := string(output)
+	// Because go routines order is undefined, we expect output to be length 3 and contain A, B, and C
+	if len(strOutput) != 3 {
+		t.Fatalf("expected output length 3, got %d", len(strOutput))
+	}
+	if !strings.Contains(strOutput, "A") || !strings.Contains(strOutput, "B") || !strings.Contains(strOutput, "C") {
+		t.Errorf("expected output to contain A, B, and C. got %s", strOutput)
+	}
+}
+
+func TestBroadcastNode_Errors(t *testing.T) {
+	bn := node.NewBroadcastNode("broadcast-err-node")
+	defer cleanupNodes(t, []node.Node{bn})
+
+	n1 := node.NewBaseNode("node1")
+	n2 := node.NewBaseNode("node2")
+	defer cleanupNodes(t, []node.Node{n1, n2})
+
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("err1")
+	})
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("err2")
+	})
+
+	bn.AddNode(n1)
+	bn.AddNode(n2)
+
+	_, err := bn.Process([]byte("input"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	errStr := err.Error()
+	if !strings.Contains(errStr, "err1") || !strings.Contains(errStr, "err2") {
+		t.Errorf("expected error to contain err1 and err2. got %s", errStr)
+	}
+}
+
+func TestBroadcastNode_Empty(t *testing.T) {
+	bn := node.NewBroadcastNode("broadcast-empty-node")
+	defer cleanupNodes(t, []node.Node{bn})
+
+	_, err := bn.Process([]byte("input"))
+	if !errors.Is(err, node.ErrNoNodes) {
+		t.Fatalf("expected ErrNoNodes, got %v", err)
+	}
+}
+
+func TestBroadcastNode_AddRemove(t *testing.T) {
+	bn := node.NewBroadcastNode("broadcast-add-remove-node")
+	defer cleanupNodes(t, []node.Node{bn})
+
+	n1 := node.NewBaseNode("node1")
+	n2 := node.NewBaseNode("node2")
+	defer cleanupNodes(t, []node.Node{n1, n2})
+
+	bn.AddNode(n1)
+	bn.AddNode(n2)
+
+	nodes := bn.GetNodes()
+	if len(nodes) != 2 {
+		t.Fatalf("expected 2 nodes, got %d", len(nodes))
+	}
+
+	bn.RemoveNode("node1")
+	nodes = bn.GetNodes()
+	if len(nodes) != 1 || nodes[0].GetID() != "node2" {
+		t.Fatalf("expected 1 node (node2), got %v", nodes)
+	}
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -26,6 +26,48 @@ func TestMiddlewares_Logging(t *testing.T) {
 	}
 }
 
+func TestMiddlewares_RateLimit(t *testing.T) {
+	n := node.NewBaseNode("rate-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	limit := 2
+	window := 50 * time.Millisecond
+	n.Use(node.RateLimitMiddleware(limit, window))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	// 1. Initial requests within limit should succeed
+	for i := 0; i < limit; i++ {
+		res, err := n.Process([]byte("input"))
+		if err != nil {
+			t.Fatalf("expected nil error on request %d, got %v", i+1, err)
+		}
+		if string(res) != "success" {
+			t.Errorf("expected success on request %d, got %s", i+1, string(res))
+		}
+	}
+
+	// 2. Request exceeding limit should fail
+	_, err := n.Process([]byte("input"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// 3. Wait for the window to pass to replenish tokens
+	time.Sleep(window + 10*time.Millisecond)
+
+	// 4. Request after window should succeed again
+	res, err := n.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("expected nil error after wait, got %v", err)
+	}
+	if string(res) != "success" {
+		t.Errorf("expected success after wait, got %s", string(res))
+	}
+}
+
 func TestMiddlewares_Retry_Success(t *testing.T) {
 	n := node.NewBaseNode("retry-node")
 	defer cleanupNodes(t, []node.Node{n})


### PR DESCRIPTION
Adds two highly requested networking components:
1. **BroadcastNode**: Provides fan-out capabilities to concurrently send incoming requests across a registered pool of destination nodes. Output and errors are collected safely.
2. **RateLimitMiddleware**: A thread-safe Token Bucket rate limiter that bounds requests within a specific `limit` over a `window` duration.

All new components include complete test coverage.

---
*PR created automatically by Jules for task [484740426166356241](https://jules.google.com/task/484740426166356241) started by @lhemerly*