### PR TITLE
docs: update readme with correct file extensions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
This PR updates the `readme.md` file to correctly point to the existing `CONTRIBUTE.md` and `LICENSE.md` files instead of incorrectly referencing `CONTRIBUTING.md` and `LICENSE`. I also verified that the rest of the documentation accurately matches the features currently implemented in the codebase.

---
*PR created automatically by Jules for task [17973668622782252244](https://jules.google.com/task/17973668622782252244) started by @lhemerly*