### PR TITLE
docs: fix contributing and license file links in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
This PR updates the `readme.md` to fix broken references to `CONTRIBUTING.md` and `LICENSE`, pointing them to the correct filenames `CONTRIBUTE.md` and `LICENSE.md`.

During the codebase review, no missing functionality was found. All node types (FailoverNode, LoadBalancerNode, PipelineNode, RouterNode, MapReduceNode), middlewares (LoggingMiddleware, RetryMiddleware, RecoveryMiddleware, CacheMiddleware, TimeoutMiddleware, CircuitBreakerMiddleware), connection packages, and event dispatching components mentioned in the readme are successfully implemented in the codebase.

---
*PR created automatically by Jules for task [12380284301471553581](https://jules.google.com/task/12380284301471553581) started by @lhemerly*