### PR TITLE
docs: Fix file reference typos in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
Fix file reference typos in readme.md

Updated `CONTRIBUTING.md` to `CONTRIBUTE.md` and `LICENSE` to `LICENSE.md` to match the actual filenames present in the repository root. Also verified the codebase functionality described in the readme matches the implemented codebase.

---
*PR created automatically by Jules for task [1743503482497589709](https://jules.google.com/task/1743503482497589709) started by @lhemerly*