### PR TITLE
docs: fix contributing file reference in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,7 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 


### PR DESCRIPTION
This PR fixes a typo in the `readme.md` where the contribution guidelines file was incorrectly referenced as `CONTRIBUTING.md` instead of the actual `CONTRIBUTE.md` file present in the repository.

Additionally, as part of the codebase review against the README, I can confirm that all functionalities mentioned in the README (e.g. `FailoverNode`, `LoadBalancerNode`, middlewares like `LoggingMiddleware`, `RetryMiddleware`, event streaming, GRPC/channel connections, etc.) are implemented accurately in the codebase. There is no missing functionality to report.

---
*PR created automatically by Jules for task [5616005359128698579](https://jules.google.com/task/5616005359128698579) started by @lhemerly*