### PR TITLE
✨ Feature: Add RateLimiting, Validation, Metrics and BroadcastNode

### DIFF
--- a/node/broadcast_node.go
+++ b/node/broadcast_node.go
@@ -1,0 +1,75 @@
+package node
+
+import (
+	"errors"
+	"sync"
+)
+
+// BroadcastNode extends BaseNode to broadcast inputs to multiple destination nodes concurrently.
+// It differs from standard Pub/Sub (Notify) by being a structural processing node
+// where the result of the broadcast is awaited during the `Process` phase.
+// It returns the original input and aggregates any errors from destinations.
+type BroadcastNode struct {
+	*BaseNode
+	destMutex    sync.RWMutex
+	destinations []Node
+}
+
+// NewBroadcastNode creates a new BroadcastNode with the given ID.
+func NewBroadcastNode(id string) *BroadcastNode {
+	b := &BroadcastNode{
+		BaseNode:     NewBaseNode(id),
+		destinations: make([]Node, 0),
+	}
+	b.SetProcessFunc(b.broadcastData)
+	return b
+}
+
+// AddDestination adds a node to the broadcast list.
+func (b *BroadcastNode) AddDestination(node Node) {
+	b.destMutex.Lock()
+	defer b.destMutex.Unlock()
+	b.destinations = append(b.destinations, node)
+}
+
+// broadcastData sends the input to all destinations concurrently and aggregates errors.
+func (b *BroadcastNode) broadcastData(input []byte) ([]byte, error) {
+	b.destMutex.RLock()
+	dests := make([]Node, len(b.destinations))
+	copy(dests, b.destinations)
+	b.destMutex.RUnlock()
+
+	if len(dests) == 0 {
+		return input, nil
+	}
+
+	var (
+		wg      sync.WaitGroup
+		errs    []error
+		errChan = make(chan error, len(dests))
+	)
+
+	for _, dest := range dests {
+		wg.Add(1)
+		go func(n Node) {
+			defer wg.Done()
+			_, err := n.Process(input)
+			if err != nil {
+				errChan <- err
+			}
+		}(dest)
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	for err := range errChan {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+
+	return input, nil
+}

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,6 +12,8 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
+	ErrValidationFailed   = errors.New("validation failed")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +59,100 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimiterMiddleware limits the number of requests using a token bucket algorithm.
+func RateLimiterMiddleware(rate int, burst int) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64 = float64(burst)
+		lastRefill time.Time = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+			now := time.Now()
+			elapsed := now.Sub(lastRefill)
+
+			// Refill tokens
+			tokens += elapsed.Seconds() * float64(rate)
+			if tokens > float64(burst) {
+				tokens = float64(burst)
+			}
+			lastRefill = now
+
+			// Check if we have enough tokens
+			if tokens >= 1.0 {
+				tokens -= 1.0
+				mu.Unlock()
+				return next(input)
+			}
+
+			mu.Unlock()
+			return nil, ErrRateLimitExceeded
+		}
+	}
+}
+
+// ValidatorMiddleware fails fast if the input does not pass the provided validation function.
+func ValidatorMiddleware(validator func([]byte) bool) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			if !validator(input) {
+				return nil, ErrValidationFailed
+			}
+			return next(input)
+		}
+	}
+}
+
+// Metrics tracks processing statistics for a node.
+type Metrics struct {
+	mu            sync.RWMutex
+	TotalRequests uint64
+	Successes     uint64
+	Errors        uint64
+	TotalDuration time.Duration
+}
+
+// Snapshot returns a copy of the current metrics.
+func (m *Metrics) Snapshot() Metrics {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return Metrics{
+		TotalRequests: m.TotalRequests,
+		Successes:     m.Successes,
+		Errors:        m.Errors,
+		TotalDuration: m.TotalDuration,
+	}
+}
+
+// MetricsMiddleware records execution metrics such as request counts and total duration.
+func MetricsMiddleware(metrics *Metrics) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			start := time.Now()
+
+			metrics.mu.Lock()
+			metrics.TotalRequests++
+			metrics.mu.Unlock()
+
+			output, err := next(input)
+			duration := time.Since(start)
+
+			metrics.mu.Lock()
+			if err != nil {
+				metrics.Errors++
+			} else {
+				metrics.Successes++
+			}
+			metrics.TotalDuration += duration
+			metrics.mu.Unlock()
+
+			return output, err
 		}
 	}
 }

--- a/node/tests/broadcast_node_test.go
+++ b/node/tests/broadcast_node_test.go
@@ -1,0 +1,91 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"sync/atomic"
+	"testing"
+)
+
+func TestBroadcastNode_Success(t *testing.T) {
+	b := node.NewBroadcastNode("broadcaster")
+	defer cleanupNodes(t, []node.Node{b})
+
+	n1 := node.NewBaseNode("dest1")
+	n2 := node.NewBaseNode("dest2")
+	defer cleanupNodes(t, []node.Node{n1, n2})
+
+	var counter1, counter2 int32
+
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		atomic.AddInt32(&counter1, 1)
+		return nil, nil
+	})
+
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		atomic.AddInt32(&counter2, 1)
+		return nil, nil
+	})
+
+	b.AddDestination(n1)
+	b.AddDestination(n2)
+
+	res, err := b.Process([]byte("broadcast-msg"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(res) != "broadcast-msg" {
+		t.Errorf("expected original input 'broadcast-msg', got %s", string(res))
+	}
+
+	if atomic.LoadInt32(&counter1) != 1 {
+		t.Errorf("expected dest1 to be called 1 time, got %d", counter1)
+	}
+	if atomic.LoadInt32(&counter2) != 1 {
+		t.Errorf("expected dest2 to be called 1 time, got %d", counter2)
+	}
+}
+
+func TestBroadcastNode_PartialFailure(t *testing.T) {
+	b := node.NewBroadcastNode("broadcaster-err")
+	defer cleanupNodes(t, []node.Node{b})
+
+	n1 := node.NewBaseNode("dest1")
+	n2 := node.NewBaseNode("dest2")
+	defer cleanupNodes(t, []node.Node{n1, n2})
+
+	expectedErr := errors.New("simulated error")
+
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, expectedErr
+	})
+
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, nil
+	})
+
+	b.AddDestination(n1)
+	b.AddDestination(n2)
+
+	_, err := b.Process([]byte("broadcast-msg"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("expected err to contain expectedErr, got: %v", err)
+	}
+}
+
+func TestBroadcastNode_NoDestinations(t *testing.T) {
+	b := node.NewBroadcastNode("broadcaster-empty")
+	defer cleanupNodes(t, []node.Node{b})
+
+	res, err := b.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(res) != "input" {
+		t.Errorf("expected 'input', got %s", string(res))
+	}
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -7,6 +7,112 @@ import (
 	"time"
 )
 
+func TestMiddlewares_RateLimiter(t *testing.T) {
+	n := node.NewBaseNode("rate-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// 10 tokens per second, burst of 2
+	n.Use(node.RateLimiterMiddleware(10, 2))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	// 1. Should succeed (token 1)
+	_, err := n.Process([]byte("req1"))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	// 2. Should succeed (token 2)
+	_, err = n.Process([]byte("req2"))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	// 3. Should fail (burst exceeded)
+	_, err = n.Process([]byte("req3"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// 4. Wait for refill (10 tokens/sec = 1 token per 100ms)
+	time.Sleep(150 * time.Millisecond)
+
+	// 5. Should succeed after refill
+	_, err = n.Process([]byte("req4"))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestMiddlewares_Validator(t *testing.T) {
+	n := node.NewBaseNode("validator-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// Validator that requires the input to be exactly "valid"
+	n.Use(node.ValidatorMiddleware(func(input []byte) bool {
+		return string(input) == "valid"
+	}))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	// 1. Should succeed
+	_, err := n.Process([]byte("valid"))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	// 2. Should fail validation
+	_, err = n.Process([]byte("invalid"))
+	if !errors.Is(err, node.ErrValidationFailed) {
+		t.Fatalf("expected ErrValidationFailed, got %v", err)
+	}
+}
+
+func TestMiddlewares_Metrics(t *testing.T) {
+	n := node.NewBaseNode("metrics-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	metrics := &node.Metrics{}
+	n.Use(node.MetricsMiddleware(metrics))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		if string(input) == "fail" {
+			return nil, errors.New("simulated failure")
+		}
+		// Simulate some processing time
+		time.Sleep(10 * time.Millisecond)
+		return []byte("success"), nil
+	})
+
+	// 1. Successful request
+	_, _ = n.Process([]byte("success1"))
+
+	// 2. Another successful request
+	_, _ = n.Process([]byte("success2"))
+
+	// 3. Failed request
+	_, _ = n.Process([]byte("fail"))
+
+	snap := metrics.Snapshot()
+
+	if snap.TotalRequests != 3 {
+		t.Errorf("expected 3 total requests, got %d", snap.TotalRequests)
+	}
+	if snap.Successes != 2 {
+		t.Errorf("expected 2 successes, got %d", snap.Successes)
+	}
+	if snap.Errors != 1 {
+		t.Errorf("expected 1 error, got %d", snap.Errors)
+	}
+	if snap.TotalDuration < 20*time.Millisecond {
+		t.Errorf("expected total duration >= 20ms, got %v", snap.TotalDuration)
+	}
+}
+
 func TestMiddlewares_Logging(t *testing.T) {
 	n := node.NewBaseNode("log-node")
 	defer cleanupNodes(t, []node.Node{n})


### PR DESCRIPTION
This PR introduces several creative and highly practical features to the Constellation framework's `node` package:

1. **`RateLimiterMiddleware`**: Implements a robust token bucket algorithm allowing developers to easily rate-limit node processing (e.g., 10 req/s with a burst of 2).
2. **`ValidatorMiddleware`**: Allows attaching a simple `func([]byte) bool` to fail-fast on invalid input data before executing costly processing logic.
3. **`MetricsMiddleware`**: Tracks critical statistics seamlessly, including total requests, successes, errors, and aggregated processing time.
4. **`BroadcastNode`**: A structural fan-out node that dispatches data to multiple destination nodes concurrently and awaits their completion, aggregating any errors into a unified response.

All features are fully tested, thread-safe, and do not introduce regressions into the existing codebase.

---
*PR created automatically by Jules for task [5201894613300716945](https://jules.google.com/task/5201894613300716945) started by @lhemerly*