### PR TITLE
docs: correct file extensions for CONTRIBUTE and LICENSE in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
This PR updates `readme.md` to reference `CONTRIBUTE.md` instead of `CONTRIBUTING.md` and `LICENSE.md` instead of `LICENSE`, fixing broken references to these files. No missing functionality was found between the codebase and the readme.

---
*PR created automatically by Jules for task [5270530573346922083](https://jules.google.com/task/5270530573346922083) started by @lhemerly*