### PR TITLE
feat(node): add BroadcastNode, WorkerPoolNode, and RateLimitMiddleware

### DIFF
--- a/node/broadcast_node.go
+++ b/node/broadcast_node.go
@@ -1,0 +1,139 @@
+package node
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// BroadcastNode extends BaseNode to broadcast incoming requests to multiple
+// destination nodes concurrently.
+type BroadcastNode struct {
+	*BaseNode
+	nodesMutex sync.RWMutex
+	nodes      []Node
+	timeout    time.Duration
+}
+
+// NewBroadcastNode creates a new BroadcastNode with the given ID.
+// The optional timeout restricts how long to wait for all nodes to complete.
+func NewBroadcastNode(id string, timeout time.Duration) *BroadcastNode {
+	bn := &BroadcastNode{
+		BaseNode: NewBaseNode(id),
+		nodes:    make([]Node, 0),
+		timeout:  timeout,
+	}
+
+	// Set the processing function to broadcast requests
+	// Note: We override Process directly instead of SetProcessFunc
+	// to ensure it handles concurrency and we don't accidentally
+	// let users overwrite the core broadcast logic with SetProcessFunc.
+	bn.BaseNode.baseProcess = bn.broadcast
+	bn.BaseNode.rebuildProcessFunc()
+
+	return bn
+}
+
+// AddNode adds a destination node to the broadcast pool.
+func (bn *BroadcastNode) AddNode(node Node) {
+	bn.nodesMutex.Lock()
+	defer bn.nodesMutex.Unlock()
+	bn.nodes = append(bn.nodes, node)
+}
+
+// GetNodes returns the current list of destination nodes.
+func (bn *BroadcastNode) GetNodes() []Node {
+	bn.nodesMutex.RLock()
+	defer bn.nodesMutex.RUnlock()
+
+	// Return a copy to avoid external modifications
+	nodesCopy := make([]Node, len(bn.nodes))
+	copy(nodesCopy, bn.nodes)
+	return nodesCopy
+}
+
+type workerResult struct {
+	output []byte
+	err    error
+}
+
+// broadcast sends the input to all nodes concurrently and waits for all of them to finish.
+func (bn *BroadcastNode) broadcast(input []byte) ([]byte, error) {
+	bn.nodesMutex.RLock()
+	nodesCount := len(bn.nodes)
+	if nodesCount == 0 {
+		bn.nodesMutex.RUnlock()
+		return nil, nil // Or an error, depending on desired semantics. Returning nil for now.
+	}
+
+	// Copy nodes to avoid holding lock during processing
+	nodesCopy := make([]Node, nodesCount)
+	copy(nodesCopy, bn.nodes)
+	bn.nodesMutex.RUnlock()
+
+	var wg sync.WaitGroup
+	resultChan := make(chan workerResult, nodesCount)
+
+	for _, n := range nodesCopy {
+		wg.Add(1)
+		go func(targetNode Node) {
+			defer wg.Done()
+			// Clone input to avoid concurrent modifications if downstream nodes mutate it
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			out, err := targetNode.Process(inputCopy)
+			resultChan <- workerResult{output: out, err: err}
+		}(n)
+	}
+
+	// Wait for all goroutines in a separate goroutine so we can use select with a timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	if bn.timeout > 0 {
+		select {
+		case <-done:
+		case <-time.After(bn.timeout):
+			return nil, errors.New("broadcast timed out")
+		}
+	} else {
+		<-done
+	}
+
+	close(resultChan)
+
+	var combinedErrors []error
+	var totalLen int
+
+	// First pass: collect errors and calculate total output length
+	// We read everything from the buffered channel. We know it has nodesCount items at most.
+	// Since done is closed, all goroutines finished (or timed out, in which case we don't reach here).
+	var results []workerResult
+	for res := range resultChan {
+		results = append(results, res)
+		if res.err != nil {
+			combinedErrors = append(combinedErrors, res.err)
+		}
+		if res.output != nil {
+			totalLen += len(res.output)
+		}
+	}
+
+	if len(combinedErrors) > 0 {
+		return nil, errors.Join(combinedErrors...)
+	}
+
+	// Second pass: Combine outputs efficiently
+	combinedOutput := make([]byte, 0, totalLen)
+	for _, res := range results {
+		if res.output != nil {
+			combinedOutput = append(combinedOutput, res.output...)
+		}
+	}
+
+	return combinedOutput, nil
+}

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -159,6 +160,39 @@ func RecoveryMiddleware(next func([]byte) ([]byte, error)) func([]byte) ([]byte,
 		}()
 
 		return next(input)
+	}
+}
+
+// RateLimitMiddleware restricts the rate of processing requests.
+// It uses a token bucket algorithm to enforce the limit.
+// rate is the number of requests per second, and burst is the maximum burst size.
+func RateLimitMiddleware(rate float64, burst int) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64 = float64(burst)
+		lastUpdate time.Time = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+			now := time.Now()
+			elapsed := now.Sub(lastUpdate).Seconds()
+			lastUpdate = now
+
+			tokens += elapsed * rate
+			if tokens > float64(burst) {
+				tokens = float64(burst)
+			}
+
+			if tokens >= 1 {
+				tokens -= 1
+				mu.Unlock()
+				return next(input)
+			}
+			mu.Unlock()
+			return nil, ErrRateLimitExceeded
+		}
 	}
 }
 

--- a/node/tests/broadcast_node_test.go
+++ b/node/tests/broadcast_node_test.go
@@ -1,0 +1,100 @@
+package node_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestBroadcastNode_Success(t *testing.T) {
+	bn := node.NewBroadcastNode("broadcast-1", 1*time.Second)
+	defer cleanupNodes(t, []node.Node{bn})
+
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+	n2 := node.NewBaseNode("n2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+	defer cleanupNodes(t, []node.Node{n1, n2})
+
+	bn.AddNode(n1)
+	bn.AddNode(n2)
+
+	output, err := bn.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	outStr := string(output)
+	// Order is not guaranteed, but it should contain both A and B
+	if len(outStr) != 2 || !strings.Contains(outStr, "A") || !strings.Contains(outStr, "B") {
+		t.Errorf("expected combined output of A and B, got %s", outStr)
+	}
+}
+
+func TestBroadcastNode_Error(t *testing.T) {
+	bn := node.NewBroadcastNode("broadcast-1", 1*time.Second)
+	defer cleanupNodes(t, []node.Node{bn})
+
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("error from n1")
+	})
+	n2 := node.NewBaseNode("n2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+	defer cleanupNodes(t, []node.Node{n1, n2})
+
+	bn.AddNode(n1)
+	bn.AddNode(n2)
+
+	_, err := bn.Process([]byte("input"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "error from n1") {
+		t.Errorf("expected error to contain 'error from n1', got %v", err)
+	}
+}
+
+func TestBroadcastNode_Timeout(t *testing.T) {
+	bn := node.NewBroadcastNode("broadcast-1", 50*time.Millisecond)
+	defer cleanupNodes(t, []node.Node{bn})
+
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond)
+		return []byte("A"), nil
+	})
+	defer cleanupNodes(t, []node.Node{n1})
+
+	bn.AddNode(n1)
+
+	_, err := bn.Process([]byte("input"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if err.Error() != "broadcast timed out" {
+		t.Errorf("expected timeout error, got %v", err)
+	}
+}
+
+func TestBroadcastNode_Empty(t *testing.T) {
+	bn := node.NewBroadcastNode("broadcast-1", 1*time.Second)
+	defer cleanupNodes(t, []node.Node{bn})
+
+	output, err := bn.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if output != nil {
+		t.Errorf("expected nil output, got %s", string(output))
+	}
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -270,6 +270,44 @@ func TestMiddlewares_Timeout(t *testing.T) {
 	}
 }
 
+func TestMiddlewares_RateLimit(t *testing.T) {
+	n := node.NewBaseNode("ratelimit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// 10 requests per second, burst size of 2
+	n.Use(node.RateLimitMiddleware(10.0, 2))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	// Burst should allow 2 immediate requests
+	_, err := n.Process([]byte("input1"))
+	if err != nil {
+		t.Fatalf("expected nil error for request 1, got %v", err)
+	}
+
+	_, err = n.Process([]byte("input2"))
+	if err != nil {
+		t.Fatalf("expected nil error for request 2, got %v", err)
+	}
+
+	// 3rd request should fail immediately because burst is exhausted
+	_, err = n.Process([]byte("input3"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// Wait enough time to replenish 1 token (1/10th of a second = 100ms)
+	time.Sleep(150 * time.Millisecond)
+
+	// Should succeed now
+	_, err = n.Process([]byte("input4"))
+	if err != nil {
+		t.Fatalf("expected nil error after waiting, got %v", err)
+	}
+}
+
 func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 	n := node.NewBaseNode("cb-empty-node")
 	defer cleanupNodes(t, []node.Node{n})

--- a/node/tests/worker_pool_node_test.go
+++ b/node/tests/worker_pool_node_test.go
@@ -1,0 +1,140 @@
+package node_test
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestWorkerPoolNode_Success(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-1", 2, 5)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{wp})
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("processed: "), input...), nil
+	})
+
+	out, err := wp.Process([]byte("task1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(out) != "processed: task1" {
+		t.Errorf("expected 'processed: task1', got '%s'", string(out))
+	}
+}
+
+func TestWorkerPoolNode_Concurrency(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-2", 2, 10)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{wp})
+
+	var activeWorkers int32
+	var maxWorkers int32
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		current := atomic.AddInt32(&activeWorkers, 1)
+
+		for {
+			max := atomic.LoadInt32(&maxWorkers)
+			if current > max {
+				if atomic.CompareAndSwapInt32(&maxWorkers, max, current) {
+					break
+				}
+			} else {
+				break
+			}
+		}
+
+		time.Sleep(50 * time.Millisecond) // Simulate work
+		atomic.AddInt32(&activeWorkers, -1)
+		return nil, nil
+	})
+
+	// Send 5 requests concurrently
+	errChan := make(chan error, 5)
+	for i := 0; i < 5; i++ {
+		go func() {
+			_, err := wp.Process([]byte("data"))
+			errChan <- err
+		}()
+	}
+
+	for i := 0; i < 5; i++ {
+		if err := <-errChan; err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+
+	finalMax := atomic.LoadInt32(&maxWorkers)
+	if finalMax > 2 {
+		t.Errorf("expected max concurrency of 2, got %d", finalMax)
+	}
+}
+
+func TestWorkerPoolNode_DeleteWhileProcessing(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-3", 1, 10)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+	// No defer cleanup, we test Delete explicitly
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond) // Slow worker
+		return nil, nil
+	})
+
+	// Start a job
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := wp.Process([]byte("data"))
+		errChan <- err
+	}()
+
+	// Give it a moment to start
+	time.Sleep(10 * time.Millisecond)
+
+	// Queue some more jobs that should get deleted
+	for i := 0; i < 2; i++ {
+		go func() {
+			_, err := wp.Process([]byte("data"))
+			if !errors.Is(err, node.ErrWorkerPoolDeleted) {
+				t.Errorf("expected ErrWorkerPoolDeleted, got %v", err)
+			}
+		}()
+	}
+
+	time.Sleep(10 * time.Millisecond)
+
+	if err := wp.Delete(); err != nil {
+		t.Fatalf("failed to delete node: %v", err)
+	}
+
+	err := <-errChan
+	if err != nil && !errors.Is(err, node.ErrWorkerPoolDeleted) {
+		t.Errorf("unexpected error for first job: %v", err)
+	}
+}
+
+func TestWorkerPoolNode_DeleteBeforeProcess(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-4", 1, 10)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	if err := wp.Delete(); err != nil {
+		t.Fatalf("failed to delete node: %v", err)
+	}
+
+	_, err := wp.Process([]byte("data"))
+	if !errors.Is(err, node.ErrWorkerPoolDeleted) {
+		t.Errorf("expected ErrWorkerPoolDeleted, got %v", err)
+	}
+}

--- a/node/worker_pool_node.go
+++ b/node/worker_pool_node.go
@@ -1,0 +1,145 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+var ErrWorkerPoolDeleted = errors.New("worker pool deleted")
+
+type jobRequest struct {
+	input      []byte
+	resultChan chan<- workerResult
+}
+
+// WorkerPoolNode manages a pool of worker goroutines to process requests,
+// limiting maximum concurrency.
+type WorkerPoolNode struct {
+	*BaseNode
+	workerCount int
+	jobChan     chan jobRequest
+	wg          sync.WaitGroup
+	ctx         context.Context
+	cancel      context.CancelFunc
+}
+
+// NewWorkerPoolNode creates a new WorkerPoolNode.
+func NewWorkerPoolNode(id string, workerCount int, queueSize int) *WorkerPoolNode {
+	ctx, cancel := context.WithCancel(context.Background())
+	wp := &WorkerPoolNode{
+		BaseNode:    NewBaseNode(id),
+		workerCount: workerCount,
+		jobChan:     make(chan jobRequest, queueSize),
+		ctx:         ctx,
+		cancel:      cancel,
+	}
+
+	// Important: We don't overwrite SetProcessFunc so users can provide their business logic.
+	// Instead, we wrap the baseProcess so we can queue calls.
+	// Actually, overriding Process directly is safer so users don't break the queue mechanism.
+	// If users call SetProcessFunc, it updates processFunc. We should queue the call to processFunc.
+
+	// Default process function if none is set
+	return wp
+}
+
+// Create starts the worker goroutines.
+func (wp *WorkerPoolNode) Create() error {
+	if err := wp.BaseNode.Create(); err != nil {
+		return err
+	}
+
+	for i := 0; i < wp.workerCount; i++ {
+		wp.wg.Add(1)
+		go wp.worker()
+	}
+
+	return nil
+}
+
+// Delete shuts down the worker pool gracefully.
+func (wp *WorkerPoolNode) Delete() error {
+	// Signal workers to stop
+	wp.cancel()
+
+	// Wait for all workers to exit
+	wp.wg.Wait()
+
+	// Drain any pending jobs and return error
+	// Safe to do this now since workers have exited and context is canceled,
+	// so no new jobs can successfully send to jobChan. Wait, concurrent Process
+	// calls might be blocked on sending. The select in Process handles ctx.Done().
+
+	// To prevent "send on closed channel" if a late Process caller tries to send
+	// while we're closing, we don't actually close(wp.jobChan). We just drain it.
+	// Process checks ctx.Done() and avoids sending.
+
+	// Drain the channel
+	for {
+		select {
+		case req := <-wp.jobChan:
+			req.resultChan <- workerResult{nil, ErrWorkerPoolDeleted}
+		default:
+			// Done draining
+			return wp.BaseNode.Delete()
+		}
+	}
+}
+
+func (wp *WorkerPoolNode) worker() {
+	defer wp.wg.Done()
+	for {
+		select {
+		case <-wp.ctx.Done():
+			return
+		case req, ok := <-wp.jobChan:
+			if !ok {
+				return
+			}
+
+			// Use the base node's process function (which includes middlewares)
+			out, err := wp.BaseNode.Process(req.input)
+
+			// Important: don't block forever if the caller went away,
+			// though resultChan is buffered by 1 so this won't block.
+			req.resultChan <- workerResult{output: out, err: err}
+		}
+	}
+}
+
+// Process overrides BaseNode.Process to route requests through the worker pool.
+func (wp *WorkerPoolNode) Process(input []byte) ([]byte, error) {
+	// Check if already shutting down
+	select {
+	case <-wp.ctx.Done():
+		return nil, ErrWorkerPoolDeleted
+	default:
+	}
+
+	// We buffer by 1 so the worker doesn't block if we return early
+	resultChan := make(chan workerResult, 1)
+
+	// Clone input to avoid race condition if caller mutates it while it's in the queue
+	inputCopy := make([]byte, len(input))
+	copy(inputCopy, input)
+
+	req := jobRequest{
+		input:      inputCopy,
+		resultChan: resultChan,
+	}
+
+	// Try to send the job
+	select {
+	case <-wp.ctx.Done():
+		return nil, ErrWorkerPoolDeleted
+	case wp.jobChan <- req:
+		// Job queued, wait for result
+		select {
+		case <-wp.ctx.Done():
+			return nil, ErrWorkerPoolDeleted
+		case res := <-resultChan:
+			return res.output, res.err
+		}
+	}
+}


### PR DESCRIPTION
Adds new features to the `node` package to enhance its capabilities for
handling complex topologies and high-concurrency scenarios:

1. **BroadcastNode**: A node that broadcasts an incoming payload to
   multiple destination nodes concurrently, with optional timeout. It
   uses channels and sync.WaitGroup to manage goroutines safely,
   avoiding panics on timeouts or early returns.
2. **WorkerPoolNode**: A node that manages a pool of worker goroutines
   to process requests, bounding maximum concurrency. It includes robust
   graceful shutdown handling, ensuring pending jobs in the queue are
   safely drained and concurrent callers receive errors without
   blocking indefinitely.
3. **RateLimitMiddleware**: A middleware that restricts the rate of
   processing requests using a token bucket algorithm to protect
   downstream services from traffic bursts.

All features include comprehensive unit tests covering success, error,
concurrency, timeout, and teardown scenarios.

---
*PR created automatically by Jules for task [2712118647469052380](https://jules.google.com/task/2712118647469052380) started by @lhemerly*