### PR TITLE
docs: fix broken links in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
I have reviewed the codebase against the README and confirmed that all functionalities described in the README (including Advanced Node Types, Middlewares, Event, and Connection packages) are present and properly implemented in the codebase. There is no missing functionality. The only issue found was that the references to `CONTRIBUTING.md` and `LICENSE` in the README were incorrect, as the actual files are named `CONTRIBUTE.md` and `LICENSE.md`. These links have been corrected.

---
*PR created automatically by Jules for task [14433996198120905075](https://jules.google.com/task/14433996198120905075) started by @lhemerly*