### PR TITLE
docs: fix incorrect file references in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
Fixes incorrect file references in `readme.md` to point to the actual files present in the repository (`CONTRIBUTE.md` and `LICENSE.md`).

---
*PR created automatically by Jules for task [7398450302655753003](https://jules.google.com/task/7398450302655753003) started by @lhemerly*