### PR TITLE
feat(node): add RateLimiter, ScatterGatherNode, and WorkerPoolNode

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +58,46 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimiterMiddleware limits the number of requests processed over time using a Token Bucket algorithm.
+// refillRate is the time duration required to accrue a single token. burstCapacity is the maximum number of tokens.
+func RateLimiterMiddleware(refillRate time.Duration, burstCapacity int) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     int = burstCapacity
+		lastRefill     = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+			now := time.Now()
+
+			// Refill tokens
+			elapsed := now.Sub(lastRefill)
+			tokensToAdd := int(elapsed / refillRate)
+
+			if tokensToAdd > 0 {
+				tokens += tokensToAdd
+				if tokens > burstCapacity {
+					tokens = burstCapacity
+				}
+				// update the lastRefill timestamp by adding the exact duration for the accrued tokens
+				// rather than resetting it to time.Now() to prevent micro-drifts and token leakage.
+				lastRefill = lastRefill.Add(time.Duration(tokensToAdd) * refillRate)
+			}
+
+			if tokens > 0 {
+				tokens--
+				mu.Unlock()
+				return next(input)
+			}
+
+			mu.Unlock()
+			return nil, ErrRateLimitExceeded
 		}
 	}
 }

--- a/node/scatter_gather_node.go
+++ b/node/scatter_gather_node.go
@@ -1,0 +1,100 @@
+package node
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrScatterGatherTimeout is returned when the ScatterGatherNode times out
+// and no successful results were gathered.
+var ErrScatterGatherTimeout = errors.New("scatter-gather timeout with no successful results")
+
+// ScatterGatherNode broadcasts input to multiple destination nodes concurrently,
+// waits for their responses up to a configurable timeout, and aggregates successful results.
+type ScatterGatherNode struct {
+	*BaseNode
+	destinationsMutex sync.RWMutex
+	destinations      []Node
+	timeout           time.Duration
+}
+
+// NewScatterGatherNode creates a new ScatterGatherNode with the given ID and timeout.
+func NewScatterGatherNode(id string, timeout time.Duration) *ScatterGatherNode {
+	sg := &ScatterGatherNode{
+		BaseNode:     NewBaseNode(id),
+		destinations: make([]Node, 0),
+		timeout:      timeout,
+	}
+
+	sg.SetProcessFunc(sg.scatterGatherProcess)
+	return sg
+}
+
+// AddDestination adds a destination node to broadcast to.
+func (sg *ScatterGatherNode) AddDestination(node Node) {
+	sg.destinationsMutex.Lock()
+	defer sg.destinationsMutex.Unlock()
+	sg.destinations = append(sg.destinations, node)
+}
+
+// scatterGatherProcess broadcasts the input to all destinations, gathers results
+// within the timeout, and concatenates successful outputs.
+func (sg *ScatterGatherNode) scatterGatherProcess(input []byte) ([]byte, error) {
+	sg.destinationsMutex.RLock()
+	dests := make([]Node, len(sg.destinations))
+	copy(dests, sg.destinations)
+	sg.destinationsMutex.RUnlock()
+
+	if len(dests) == 0 {
+		return nil, nil // No destinations to broadcast to
+	}
+
+	type workerResult struct {
+		output []byte
+		err    error
+	}
+
+	// We use a buffered channel to prevent goroutine leaks if they finish after the timeout.
+	resultsChan := make(chan workerResult, len(dests))
+
+	for _, dest := range dests {
+		go func(n Node) {
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			res, err := n.Process(inputCopy)
+			resultsChan <- workerResult{output: res, err: err}
+		}(dest)
+	}
+
+	var finalOutput []byte
+	var errs []error
+	received := 0
+
+	timeoutChan := time.After(sg.timeout)
+
+GatherLoop:
+	for received < len(dests) {
+		select {
+		case result := <-resultsChan:
+			received++
+			if result.err != nil {
+				errs = append(errs, result.err)
+			} else {
+				finalOutput = append(finalOutput, result.output...)
+			}
+		case <-timeoutChan:
+			errs = append(errs, ErrScatterGatherTimeout)
+			break GatherLoop
+		}
+	}
+
+	// Check if we have complete failure (no successful outputs, but we had destinations)
+	// We check len(finalOutput) == 0 and len(dests) > 0.
+	if len(finalOutput) == 0 && len(dests) > 0 {
+		return nil, errors.Join(append([]error{errors.New("scatter-gather failed completely")}, errs...)...)
+	}
+
+	return finalOutput, nil
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -241,6 +241,59 @@ func TestMiddlewares_Cache(t *testing.T) {
 	}
 }
 
+func TestMiddlewares_RateLimiter(t *testing.T) {
+	n := node.NewBaseNode("rate-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// 100ms per token, max 2 tokens burst
+	n.Use(node.RateLimiterMiddleware(100*time.Millisecond, 2))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("ok"), nil
+	})
+
+	// Consume burst capacity
+	res, err := n.Process([]byte("req1"))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if string(res) != "ok" {
+		t.Errorf("expected ok, got %s", string(res))
+	}
+
+	res, err = n.Process([]byte("req2"))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	if string(res) != "ok" {
+		t.Errorf("expected ok, got %s", string(res))
+	}
+
+	// Next request should fail
+	_, err = n.Process([]byte("req3"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// Wait for 1 token to refill (100ms) + a little buffer
+	time.Sleep(120 * time.Millisecond)
+
+	// Should succeed now
+	res, err = n.Process([]byte("req4"))
+	if err != nil {
+		t.Fatalf("expected nil error after wait, got %v", err)
+	}
+	if string(res) != "ok" {
+		t.Errorf("expected ok, got %s", string(res))
+	}
+
+	// Next request should fail again since we only refilled 1 token
+	_, err = n.Process([]byte("req5"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+}
+
 func TestMiddlewares_Timeout(t *testing.T) {
 	n := node.NewBaseNode("timeout-node")
 	defer cleanupNodes(t, []node.Node{n})

--- a/node/tests/scatter_gather_node_test.go
+++ b/node/tests/scatter_gather_node_test.go
@@ -1,0 +1,137 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestScatterGatherNode_Success(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg-1", 100*time.Millisecond)
+	defer cleanupNodes(t, []node.Node{sg})
+
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+
+	n2 := node.NewBaseNode("n2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+
+	sg.AddDestination(n1)
+	sg.AddDestination(n2)
+
+	res, err := sg.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resultStr := string(res)
+	if !strings.Contains(resultStr, "A") || !strings.Contains(resultStr, "B") {
+		t.Errorf("expected result to contain A and B, got %s", resultStr)
+	}
+	if len(resultStr) != 2 {
+		t.Errorf("expected length 2, got %d", len(resultStr))
+	}
+}
+
+func TestScatterGatherNode_PartialTimeout(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg-2", 50*time.Millisecond)
+	defer cleanupNodes(t, []node.Node{sg})
+
+	n1 := node.NewBaseNode("fast")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("F"), nil
+	})
+
+	n2 := node.NewBaseNode("slow")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond)
+		return []byte("S"), nil
+	})
+
+	sg.AddDestination(n1)
+	sg.AddDestination(n2)
+
+	res, err := sg.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error on partial success: %v", err)
+	}
+
+	if string(res) != "F" {
+		t.Errorf("expected result to be F, got %s", string(res))
+	}
+}
+
+func TestScatterGatherNode_CompleteTimeout(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg-3", 50*time.Millisecond)
+	defer cleanupNodes(t, []node.Node{sg})
+
+	n1 := node.NewBaseNode("slow1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond)
+		return []byte("S1"), nil
+	})
+
+	n2 := node.NewBaseNode("slow2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond)
+		return []byte("S2"), nil
+	})
+
+	sg.AddDestination(n1)
+	sg.AddDestination(n2)
+
+	_, err := sg.Process([]byte("input"))
+	if err == nil {
+		t.Fatalf("expected error on complete failure, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "scatter-gather failed completely") {
+		t.Errorf("expected error to mention total failure, got %v", err)
+	}
+}
+
+func TestScatterGatherNode_EmptyDestinations(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg-empty", 100*time.Millisecond)
+	defer cleanupNodes(t, []node.Node{sg})
+
+	res, err := sg.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res != nil {
+		t.Errorf("expected nil result for empty destinations, got %v", res)
+	}
+}
+
+func TestScatterGatherNode_NodeError(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg-err", 100*time.Millisecond)
+	defer cleanupNodes(t, []node.Node{sg})
+
+	n1 := node.NewBaseNode("success")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("OK"), nil
+	})
+
+	n2 := node.NewBaseNode("fail")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("expected failure")
+	})
+
+	sg.AddDestination(n1)
+	sg.AddDestination(n2)
+
+	res, err := sg.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error on partial success: %v", err)
+	}
+
+	if string(res) != "OK" {
+		t.Errorf("expected OK, got %s", string(res))
+	}
+}

--- a/node/tests/worker_pool_node_test.go
+++ b/node/tests/worker_pool_node_test.go
@@ -1,0 +1,101 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWorkerPoolNode_Success(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-1", 2, 5)
+
+	var processedCount int32
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		atomic.AddInt32(&processedCount, 1)
+		return nil, nil
+	})
+
+	err := wp.Create()
+	if err != nil {
+		t.Fatalf("failed to create worker pool: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		res, err := wp.Process([]byte("task"))
+		if err != nil {
+			t.Fatalf("unexpected error queueing task: %v", err)
+		}
+		if string(res) != "accepted" {
+			t.Errorf("expected accepted, got %s", string(res))
+		}
+	}
+
+	// Wait for workers to process tasks
+	time.Sleep(100 * time.Millisecond)
+
+	count := atomic.LoadInt32(&processedCount)
+	if count != 5 {
+		t.Errorf("expected 5 processed tasks, got %d", count)
+	}
+
+	err = wp.Delete()
+	if err != nil {
+		t.Fatalf("failed to delete worker pool: %v", err)
+	}
+}
+
+func TestWorkerPoolNode_QueueFull(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-full", 1, 1)
+
+	// Worker sleeps to block the queue
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond)
+		return nil, nil
+	})
+
+	err := wp.Create()
+	if err != nil {
+		t.Fatalf("failed to create worker pool: %v", err)
+	}
+	defer wp.Delete()
+
+	// Fill the worker and the queue
+	_, err = wp.Process([]byte("task1")) // Worker takes it
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Wait a moment for the worker to pull task1 from the queue
+	time.Sleep(10 * time.Millisecond)
+
+	_, err = wp.Process([]byte("task2")) // Queue takes it
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// This should fail because queue is full
+	_, err = wp.Process([]byte("task3"))
+	if !errors.Is(err, node.ErrQueueFull) {
+		t.Fatalf("expected ErrQueueFull, got %v", err)
+	}
+}
+
+func TestWorkerPoolNode_ClosedPool(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-closed", 1, 1)
+	err := wp.Create()
+	if err != nil {
+		t.Fatalf("failed to create worker pool: %v", err)
+	}
+
+	err = wp.Delete()
+	if err != nil {
+		t.Fatalf("failed to delete worker pool: %v", err)
+	}
+
+	_, err = wp.Process([]byte("task"))
+	if !errors.Is(err, node.ErrWorkerPoolClosed) {
+		t.Fatalf("expected ErrWorkerPoolClosed, got %v", err)
+	}
+}

--- a/node/worker_pool_node.go
+++ b/node/worker_pool_node.go
@@ -1,0 +1,137 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// ErrQueueFull is returned when the internal job queue is full and cannot accept more requests.
+var ErrQueueFull = errors.New("worker pool queue is full")
+
+// ErrWorkerPoolClosed is returned if a process is attempted on a closed worker pool.
+var ErrWorkerPoolClosed = errors.New("worker pool is closed")
+
+// WorkerPoolNode processes requests asynchronously using a fixed pool of background goroutines.
+type WorkerPoolNode struct {
+	*BaseNode
+	workers    int
+	queue      chan []byte
+	cancelFunc context.CancelFunc
+	ctx        context.Context
+	wg         sync.WaitGroup
+	closed     bool
+	closeMutex sync.RWMutex
+}
+
+// NewWorkerPoolNode creates a new WorkerPoolNode with the given ID, number of workers, and queue capacity.
+func NewWorkerPoolNode(id string, workers int, queueCapacity int) *WorkerPoolNode {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	wp := &WorkerPoolNode{
+		BaseNode:   NewBaseNode(id),
+		workers:    workers,
+		queue:      make(chan []byte, queueCapacity),
+		cancelFunc: cancel,
+		ctx:        ctx,
+	}
+
+	// Override Process directly, as intercepting via SetProcessFunc for queueing
+	// is not recommended (users might overwrite it).
+	// We will handle queueing in Process, and worker processing via BaseNode.Process
+	// to ensure middlewares and event counters are respected.
+
+	return wp
+}
+
+// Create starts the worker pool goroutines.
+func (wp *WorkerPoolNode) Create() error {
+	if err := wp.BaseNode.Create(); err != nil {
+		return err
+	}
+
+	for i := 0; i < wp.workers; i++ {
+		wp.wg.Add(1)
+		go wp.worker()
+	}
+
+	return nil
+}
+
+// Process queues the input for asynchronous processing.
+// Returns an immediate "accepted" response or ErrQueueFull if the queue is full.
+func (wp *WorkerPoolNode) Process(input []byte) ([]byte, error) {
+	wp.closeMutex.RLock()
+	defer wp.closeMutex.RUnlock()
+
+	if wp.closed {
+		return nil, ErrWorkerPoolClosed
+	}
+
+	// Priority: check context cancellation first
+	select {
+	case <-wp.ctx.Done():
+		return nil, ErrWorkerPoolClosed
+	default:
+	}
+
+	// Clone input for async processing
+	inputCopy := make([]byte, len(input))
+	copy(inputCopy, input)
+
+	select {
+	case wp.queue <- inputCopy:
+		return []byte("accepted"), nil
+	case <-wp.ctx.Done():
+		return nil, ErrWorkerPoolClosed
+	default:
+		return nil, ErrQueueFull
+	}
+}
+
+// worker continuously processes jobs from the queue until context is cancelled.
+func (wp *WorkerPoolNode) worker() {
+	defer wp.wg.Done()
+
+	for {
+		select {
+		case <-wp.ctx.Done():
+			return
+		case input, ok := <-wp.queue:
+			if !ok {
+				return
+			}
+			// Invoke base Process to run middlewares and processFunc
+			_, _ = wp.BaseNode.Process(input)
+		}
+	}
+}
+
+// Delete gracefully shuts down the worker pool and its base node.
+func (wp *WorkerPoolNode) Delete() error {
+	wp.closeMutex.Lock()
+	if wp.closed {
+		wp.closeMutex.Unlock()
+		return nil
+	}
+	wp.closed = true
+	wp.closeMutex.Unlock()
+
+	// Signal workers to stop
+	wp.cancelFunc()
+
+	// Wait for workers to finish
+	wp.wg.Wait()
+
+	// Safely drain the queue without closing the channel, as concurrent
+	// Process calls might still hold RLock, but since we cancel ctx first,
+	// they will return ErrWorkerPoolClosed. However, some might be blocked
+	// on channel send. Context cancellation handles this.
+	// We still drain the queue for clean shutdown.
+	close(wp.queue)
+	for range wp.queue {
+		// drain
+	}
+
+	return wp.BaseNode.Delete()
+}


### PR DESCRIPTION
This PR introduces three new powerful features to the `node` package to enhance capabilities for high-performance and resilient networking:

1.  **RateLimiter Middleware**: A Token Bucket rate limiter that restricts incoming requests.
2.  **ScatterGatherNode**: A structural node that broadcasts input to multiple destinations concurrently, waits for their responses up to a configurable timeout, and aggregates the successful results.
3.  **WorkerPoolNode**: An asynchronous processing node that queues incoming requests into an internal channel and processes them using a fixed pool of background goroutines.

All features are fully tested, addressing concurrent edge cases and safe shutdown protocols.

---
*PR created automatically by Jules for task [970361711329097139](https://jules.google.com/task/970361711329097139) started by @lhemerly*