### PR TITLE
feat: Add RateLimitMiddleware, ScatterGatherNode, and WorkerPoolNode

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,7 +12,52 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
+
+// RateLimitMiddleware enforces a token bucket rate limit on processing.
+func RateLimitMiddleware(capacity int, refillRate time.Duration) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     int = capacity
+		lastRefill time.Time
+	)
+
+	// Avoid uninitialized time if first request comes in immediately
+	lastRefill = time.Now()
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+
+			// Refill tokens
+			now := time.Now()
+			elapsed := now.Sub(lastRefill)
+			tokensToAdd := int(elapsed / refillRate)
+
+			if tokensToAdd > 0 {
+				tokens += tokensToAdd
+				if tokens > capacity {
+					tokens = capacity
+				}
+
+				// Instead of resetting to time.Now(), advance lastRefill by the exact duration
+				// corresponding to the accrued tokens. This prevents micro-drifts and token leakage.
+				lastRefill = lastRefill.Add(time.Duration(tokensToAdd) * refillRate)
+			}
+
+			if tokens <= 0 {
+				mu.Unlock()
+				return nil, ErrRateLimitExceeded
+			}
+
+			tokens--
+			mu.Unlock()
+
+			return next(input)
+		}
+	}
+}
 
 // LoggingMiddleware logs the payload size and processing time.
 func LoggingMiddleware(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {

--- a/node/scatter_gather_node.go
+++ b/node/scatter_gather_node.go
@@ -1,0 +1,103 @@
+package node
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrScatterGatherTimeout is returned when the scatter-gather process times out without successful responses.
+var ErrScatterGatherTimeout = errors.New("scatter-gather timed out")
+
+// ErrScatterGatherFailed is returned when all destination nodes fail to process the request.
+var ErrScatterGatherFailed = errors.New("scatter-gather failed on all destinations")
+
+// ScatterGatherNode extends BaseNode to broadcast requests to multiple destinations
+// and gather the first successful results within a timeout.
+type ScatterGatherNode struct {
+	*BaseNode
+	destinationsMutex sync.RWMutex
+	destinations      []Node
+	timeout           time.Duration
+}
+
+// NewScatterGatherNode creates a new ScatterGatherNode.
+func NewScatterGatherNode(id string, timeout time.Duration) *ScatterGatherNode {
+	sg := &ScatterGatherNode{
+		BaseNode:     NewBaseNode(id),
+		destinations: make([]Node, 0),
+		timeout:      timeout,
+	}
+	sg.SetProcessFunc(sg.scatterGatherProcess)
+	return sg
+}
+
+// AddDestination adds a target node to the scatter-gather group.
+func (sg *ScatterGatherNode) AddDestination(n Node) {
+	sg.destinationsMutex.Lock()
+	defer sg.destinationsMutex.Unlock()
+	sg.destinations = append(sg.destinations, n)
+}
+
+func (sg *ScatterGatherNode) scatterGatherProcess(input []byte) ([]byte, error) {
+	sg.destinationsMutex.RLock()
+	dests := make([]Node, len(sg.destinations))
+	copy(dests, sg.destinations)
+	sg.destinationsMutex.RUnlock()
+
+	if len(dests) == 0 {
+		return nil, errors.New("no destinations configured")
+	}
+
+	type result struct {
+		output []byte
+		err    error
+	}
+
+	// Buffered channel to prevent goroutine leaks if they finish after timeout
+	resultsChan := make(chan result, len(dests))
+
+	for _, dest := range dests {
+		go func(n Node) {
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			out, err := n.Process(inputCopy)
+			resultsChan <- result{output: out, err: err}
+		}(dest)
+	}
+
+	var errs []error
+	var finalOutput [][]byte
+
+	timeoutChan := time.After(sg.timeout)
+
+GatherLoop:
+	for i := 0; i < len(dests); i++ {
+		select {
+		case res := <-resultsChan:
+			if res.err != nil {
+				errs = append(errs, res.err)
+			} else {
+				finalOutput = append(finalOutput, res.output)
+			}
+		case <-timeoutChan:
+			break GatherLoop
+		}
+	}
+
+	if len(finalOutput) > 0 {
+		// Just concatenating the outputs for this node type
+		var combined []byte
+		for _, out := range finalOutput {
+			combined = append(combined, out...)
+		}
+		return combined, nil
+	}
+
+	if len(errs) == len(dests) {
+		return nil, errors.Join(append([]error{ErrScatterGatherFailed}, errs...)...)
+	}
+
+	return nil, ErrScatterGatherTimeout
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -7,6 +7,44 @@ import (
 	"time"
 )
 
+func TestMiddlewares_RateLimit(t *testing.T) {
+	n := node.NewBaseNode("rate-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// 2 tokens, refills 1 token every 100ms
+	n.Use(node.RateLimitMiddleware(2, 100*time.Millisecond))
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return input, nil
+	})
+
+	// 1st request should pass
+	_, err := n.Process([]byte("req1"))
+	if err != nil {
+		t.Fatalf("expected 1st request to pass, got: %v", err)
+	}
+
+	// 2nd request should pass
+	_, err = n.Process([]byte("req2"))
+	if err != nil {
+		t.Fatalf("expected 2nd request to pass, got: %v", err)
+	}
+
+	// 3rd request should fail immediately
+	_, err = n.Process([]byte("req3"))
+	if err != node.ErrRateLimitExceeded {
+		t.Fatalf("expected ErrRateLimitExceeded, got: %v", err)
+	}
+
+	// Wait for refill (100ms + small buffer)
+	time.Sleep(120 * time.Millisecond)
+
+	// 4th request should pass again
+	_, err = n.Process([]byte("req4"))
+	if err != nil {
+		t.Fatalf("expected 4th request to pass after refill, got: %v", err)
+	}
+}
+
 func TestMiddlewares_Logging(t *testing.T) {
 	n := node.NewBaseNode("log-node")
 	defer cleanupNodes(t, []node.Node{n})

--- a/node/tests/scatter_gather_node_test.go
+++ b/node/tests/scatter_gather_node_test.go
@@ -1,0 +1,91 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"testing"
+	"time"
+)
+
+func TestScatterGatherNode_Success(t *testing.T) {
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+
+	n2 := node.NewBaseNode("n2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+
+	sg := node.NewScatterGatherNode("sg", 1*time.Second)
+	sg.AddDestination(n1)
+	sg.AddDestination(n2)
+
+	defer cleanupNodes(t, []node.Node{n1, n2, sg})
+
+	out, err := sg.Process([]byte("test"))
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+
+	strOut := string(out)
+	if strOut != "AB" && strOut != "BA" {
+		t.Fatalf("expected output to be AB or BA, got: %s", strOut)
+	}
+}
+
+func TestScatterGatherNode_Timeout(t *testing.T) {
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(200 * time.Millisecond)
+		return []byte("A"), nil
+	})
+
+	sg := node.NewScatterGatherNode("sg", 50*time.Millisecond)
+	sg.AddDestination(n1)
+
+	defer cleanupNodes(t, []node.Node{n1, sg})
+
+	_, err := sg.Process([]byte("test"))
+	if err != node.ErrScatterGatherTimeout {
+		t.Fatalf("expected timeout error, got: %v", err)
+	}
+}
+
+func TestScatterGatherNode_AllFailed(t *testing.T) {
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("fail 1")
+	})
+
+	n2 := node.NewBaseNode("n2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("fail 2")
+	})
+
+	sg := node.NewScatterGatherNode("sg", 1*time.Second)
+	sg.AddDestination(n1)
+	sg.AddDestination(n2)
+
+	defer cleanupNodes(t, []node.Node{n1, n2, sg})
+
+	_, err := sg.Process([]byte("test"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if !errors.Is(err, node.ErrScatterGatherFailed) {
+		t.Fatalf("expected ErrScatterGatherFailed in error chain, got: %v", err)
+	}
+}
+
+func TestScatterGatherNode_NoDestinations(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg", 1*time.Second)
+	defer cleanupNodes(t, []node.Node{sg})
+
+	_, err := sg.Process([]byte("test"))
+	if err == nil || err.Error() != "no destinations configured" {
+		t.Fatalf("expected 'no destinations configured' error, got: %v", err)
+	}
+}

--- a/node/tests/worker_pool_node_test.go
+++ b/node/tests/worker_pool_node_test.go
@@ -1,0 +1,94 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWorkerPoolNode_Success(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp", 2, 5)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{wp})
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("processed "), input...), nil
+	})
+
+	var wg sync.WaitGroup
+	results := make([]string, 4)
+	errs := make([]error, 4)
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			out, err := wp.Process([]byte("task"))
+			results[idx] = string(out)
+			errs[idx] = err
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i := 0; i < 4; i++ {
+		if errs[i] != nil {
+			t.Errorf("expected success for task %d, got: %v", i, errs[i])
+		}
+		if results[i] != "processed task" {
+			t.Errorf("expected 'processed task', got: %s", results[i])
+		}
+	}
+}
+
+func TestWorkerPoolNode_QueueFull(t *testing.T) {
+	// 1 worker, 1 queue size = max 2 concurrent requests before blocking
+	wp := node.NewWorkerPoolNode("wp", 1, 1)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{wp})
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond) // Block the worker
+		return input, nil
+	})
+
+	// Fill worker
+	go wp.Process([]byte("1"))
+	time.Sleep(10 * time.Millisecond)
+
+	// Fill queue
+	go wp.Process([]byte("2"))
+	time.Sleep(10 * time.Millisecond)
+
+	// This should fail
+	_, err := wp.Process([]byte("3"))
+	if err != node.ErrWorkerPoolFull {
+		t.Fatalf("expected ErrWorkerPoolFull, got: %v", err)
+	}
+}
+
+func TestWorkerPoolNode_Deleted(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp", 1, 1)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return input, nil
+	})
+
+	if err := wp.Delete(); err != nil {
+		t.Fatalf("failed to delete node: %v", err)
+	}
+
+	_, err := wp.Process([]byte("test"))
+	if !errors.Is(err, node.ErrWorkerPoolDeleted) {
+		t.Fatalf("expected ErrWorkerPoolDeleted, got: %v", err)
+	}
+}

--- a/node/worker_pool_node.go
+++ b/node/worker_pool_node.go
@@ -1,0 +1,125 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// ErrWorkerPoolFull is returned when the worker pool queue is full.
+var ErrWorkerPoolFull = errors.New("worker pool queue is full")
+
+// ErrWorkerPoolDeleted is returned when a process is attempted on a deleted pool.
+var ErrWorkerPoolDeleted = errors.New("worker pool has been deleted")
+
+type job struct {
+	input      []byte
+	resultChan chan result
+}
+
+type result struct {
+	output []byte
+	err    error
+}
+
+// WorkerPoolNode extends BaseNode to process requests concurrently
+// using a bounded pool of worker goroutines and a job queue.
+type WorkerPoolNode struct {
+	*BaseNode
+	workers    int
+	jobChan    chan job
+	wg         sync.WaitGroup
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+}
+
+// NewWorkerPoolNode creates a new WorkerPoolNode.
+func NewWorkerPoolNode(id string, workers int, queueSize int) *WorkerPoolNode {
+	ctx, cancel := context.WithCancel(context.Background())
+	wp := &WorkerPoolNode{
+		BaseNode:   NewBaseNode(id),
+		workers:    workers,
+		jobChan:    make(chan job, queueSize),
+		ctx:        ctx,
+		cancelFunc: cancel,
+	}
+
+	return wp
+}
+
+// Create initializes the node and starts the worker pool.
+func (wp *WorkerPoolNode) Create() error {
+	if err := wp.BaseNode.Create(); err != nil {
+		return err
+	}
+
+	for i := 0; i < wp.workers; i++ {
+		wp.wg.Add(1)
+		go wp.worker()
+	}
+
+	return nil
+}
+
+// Delete cleanly shuts down the worker pool, preventing new jobs and draining the queue.
+func (wp *WorkerPoolNode) Delete() error {
+	wp.cancelFunc()
+	wp.wg.Wait()
+
+	// Drain any remaining jobs in the channel to prevent hanging callers
+DrainLoop:
+	for {
+		select {
+		case j := <-wp.jobChan:
+			j.resultChan <- result{nil, ErrWorkerPoolDeleted}
+		default:
+			break DrainLoop
+		}
+	}
+
+	return wp.BaseNode.Delete()
+}
+
+func (wp *WorkerPoolNode) worker() {
+	defer wp.wg.Done()
+	for {
+		select {
+		case <-wp.ctx.Done():
+			return
+		case j := <-wp.jobChan:
+			// Process via BaseNode to execute middlewares and custom logic
+			out, err := wp.BaseNode.Process(j.input)
+			j.resultChan <- result{out, err}
+		}
+	}
+}
+
+// Process enqueues a job or returns an error if the queue is full or deleted.
+func (wp *WorkerPoolNode) Process(input []byte) ([]byte, error) {
+	// Check context first to avoid sending to channel if deleted
+	select {
+	case <-wp.ctx.Done():
+		return nil, ErrWorkerPoolDeleted
+	default:
+	}
+
+	resChan := make(chan result, 1)
+	j := job{input: input, resultChan: resChan}
+
+	select {
+	case <-wp.ctx.Done():
+		return nil, ErrWorkerPoolDeleted
+	case wp.jobChan <- j:
+		// Job queued successfully
+	default:
+		return nil, ErrWorkerPoolFull
+	}
+
+	// Wait for processing to complete or pool to be deleted
+	select {
+	case res := <-resChan:
+		return res.output, res.err
+	case <-wp.ctx.Done():
+		return nil, ErrWorkerPoolDeleted
+	}
+}


### PR DESCRIPTION
This PR introduces three new powerful features to the `node` package to support more complex processing architectures and improve node resilience:

1.  **RateLimitMiddleware**: A middleware that limits the processing rate using a token-bucket algorithm, preventing downstream nodes from being overwhelmed. It handles micro-drifts gracefully by updating the refill timestamp directly using the exact time elapsed for consumed tokens.
2.  **ScatterGatherNode**: A structural node that concurrently broadcasts incoming requests to multiple destination nodes, gathering and concatenating the first successful responses within a configured timeout. This is useful for high-availability reads or parallel queries.
3.  **WorkerPoolNode**: A concurrency-limiting node that queues incoming requests and processes them using a fixed-size pool of background worker goroutines. It safely handles context cancellation during teardown and prevents "send on closed channel" panics.

All new features are heavily tested, covering success paths, edge cases (like timeouts, full queues, and deleted pools), and failure modes.

---
*PR created automatically by Jules for task [5329302083955973423](https://jules.google.com/task/5329302083955973423) started by @lhemerly*