### PR TITLE
feat: Introduce Rate Limiting, Worker Pools, and Scatter-Gather Patterns

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +58,48 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimitMiddleware limits the number of requests that can be processed per second using a token bucket algorithm.
+func RateLimitMiddleware(capacity int, refillRate time.Duration) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     int
+		lastRefill time.Time
+	)
+
+	// Initialize the bucket full
+	tokens = capacity
+	lastRefill = time.Now()
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+
+			now := time.Now()
+			elapsed := now.Sub(lastRefill)
+
+			// Refill tokens
+			tokensToAdd := int(elapsed / refillRate)
+			if tokensToAdd > 0 {
+				tokens += tokensToAdd
+				if tokens > capacity {
+					tokens = capacity
+				}
+				// Advance lastRefill by the exact duration for the accrued tokens
+				lastRefill = lastRefill.Add(time.Duration(tokensToAdd) * refillRate)
+			}
+
+			if tokens > 0 {
+				tokens--
+				mu.Unlock()
+				return next(input)
+			}
+
+			mu.Unlock()
+			return nil, ErrRateLimitExceeded
 		}
 	}
 }

--- a/node/scatter_gather_node.go
+++ b/node/scatter_gather_node.go
@@ -1,0 +1,140 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ScatterGatherNode broadcasts a request concurrently to a set of destination nodes
+// and returns the first successful response, or an aggregate error if all fail or a timeout is reached.
+type ScatterGatherNode struct {
+	*BaseNode
+	targets []Node
+	timeout time.Duration
+}
+
+// NewScatterGatherNode creates a new ScatterGatherNode with a set of target nodes and a timeout.
+func NewScatterGatherNode(id string, targets []Node, timeout time.Duration) *ScatterGatherNode {
+	if len(targets) == 0 {
+		panic("ScatterGatherNode requires at least one target node")
+	}
+
+	sgNode := &ScatterGatherNode{
+		BaseNode: NewBaseNode(id),
+		targets:  targets,
+		timeout:  timeout,
+	}
+
+	sgNode.SetProcessFunc(sgNode.scatterGatherProcess)
+	return sgNode
+}
+
+func (sg *ScatterGatherNode) scatterGatherProcess(input []byte) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), sg.timeout)
+	defer cancel()
+
+	resultChan := make(chan []byte, 1)
+	errChan := make(chan error, len(sg.targets))
+	var wg sync.WaitGroup
+
+	for _, target := range sg.targets {
+		wg.Add(1)
+		go func(n Node) {
+			defer wg.Done()
+
+			// Check context before starting long work
+			select {
+			case <-ctx.Done():
+				errChan <- ctx.Err()
+				return
+			default:
+			}
+
+			// Clone input to prevent data races
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			res, err := n.Process(inputCopy)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			// Try to send result if no one else has succeeded yet
+			select {
+			case resultChan <- res:
+				cancel() // we have a winner, cancel others
+			case <-ctx.Done():
+				// already canceled, someone else won or timeout
+			}
+		}(target)
+	}
+
+	// Wait for all to finish to close errChan safely
+	doneChan := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(errChan)
+		close(doneChan)
+	}()
+
+	select {
+	case res := <-resultChan:
+		return res, nil
+	case <-doneChan:
+		// All targets completed but none succeeded (we would have returned otherwise).
+		// Collect all errors to return.
+		var errs []error
+		for err := range errChan {
+			errs = append(errs, err)
+		}
+		return nil, errors.Join(append([]error{errors.New("all targets failed")}, errs...)...)
+	case <-ctx.Done():
+		// We timed out before getting a successful result or all targets failing
+		var errs []error
+		// Non-blocking drain of currently available errors
+		drain:
+		for {
+			select {
+			case err := <-errChan:
+				errs = append(errs, err)
+			default:
+				break drain
+			}
+		}
+		errs = append(errs, ErrProcessTimeout)
+		return nil, errors.Join(append([]error{errors.New("all targets failed or timed out")}, errs...)...)
+	}
+}
+
+// Create initializes the node and its targets.
+func (sg *ScatterGatherNode) Create() error {
+	if err := sg.BaseNode.Create(); err != nil {
+		return err
+	}
+	for _, n := range sg.targets {
+		if err := n.Create(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Delete cleans up the node and its targets.
+func (sg *ScatterGatherNode) Delete() error {
+	var errs []error
+	if err := sg.BaseNode.Delete(); err != nil {
+		errs = append(errs, err)
+	}
+	for _, n := range sg.targets {
+		if err := n.Delete(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -314,3 +314,47 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
 	}
 }
+
+func TestMiddlewares_RateLimit(t *testing.T) {
+	n := node.NewBaseNode("ratelimit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// Capacity of 2, refills 1 token every 50ms
+	n.Use(node.RateLimitMiddleware(2, 50*time.Millisecond))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("ok"), nil
+	})
+
+	// 1. Initial burst (2 requests should succeed)
+	for i := 0; i < 2; i++ {
+		res, err := n.Process([]byte("input"))
+		if err != nil {
+			t.Fatalf("request %d failed: %v", i+1, err)
+		}
+		if string(res) != "ok" {
+			t.Fatalf("expected 'ok', got %s", string(res))
+		}
+	}
+
+	// 2. Exceed limit (3rd request should fail immediately)
+	_, err := n.Process([]byte("input"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// 3. Wait for 1 token to refill
+	time.Sleep(55 * time.Millisecond)
+
+	// 4. Request should now succeed
+	_, err = n.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("request after refill failed: %v", err)
+	}
+
+	// 5. Subsequent request should fail again (only 1 token refilled)
+	_, err = n.Process([]byte("input"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+}

--- a/node/tests/scatter_gather_node_test.go
+++ b/node/tests/scatter_gather_node_test.go
@@ -1,0 +1,96 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestScatterGatherNode_FirstSuccess(t *testing.T) {
+	n1 := node.NewBaseNode("t1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(50 * time.Millisecond)
+		return []byte("slow"), nil
+	})
+
+	n2 := node.NewBaseNode("t2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(10 * time.Millisecond)
+		return []byte("fast"), nil
+	})
+
+	n3 := node.NewBaseNode("t3")
+	n3.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("fail")
+	})
+
+	sg := node.NewScatterGatherNode("sg", []node.Node{n1, n2, n3}, 100*time.Millisecond)
+	if err := sg.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+	defer sg.Delete()
+
+	res, err := sg.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(res) != "fast" {
+		t.Errorf("expected 'fast', got '%s'", string(res))
+	}
+}
+
+func TestScatterGatherNode_AllFail(t *testing.T) {
+	n1 := node.NewBaseNode("t1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("fail1")
+	})
+
+	n2 := node.NewBaseNode("t2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("fail2")
+	})
+
+	sg := node.NewScatterGatherNode("sg", []node.Node{n1, n2}, 100*time.Millisecond)
+	if err := sg.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+	defer sg.Delete()
+
+	_, err := sg.Process([]byte("input"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	errStr := err.Error()
+	if !strings.Contains(errStr, "all targets failed") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+	if !strings.Contains(errStr, "fail1") || !strings.Contains(errStr, "fail2") {
+		t.Errorf("expected error to contain target errors, got: %v", err)
+	}
+}
+
+func TestScatterGatherNode_Timeout(t *testing.T) {
+	n1 := node.NewBaseNode("t1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond)
+		return []byte("slow"), nil
+	})
+
+	sg := node.NewScatterGatherNode("sg", []node.Node{n1}, 20*time.Millisecond)
+	if err := sg.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+	defer sg.Delete()
+
+	_, err := sg.Process([]byte("input"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if !errors.Is(err, node.ErrProcessTimeout) {
+		t.Errorf("expected ErrProcessTimeout, got %v", err)
+	}
+}

--- a/node/tests/worker_pool_node_test.go
+++ b/node/tests/worker_pool_node_test.go
@@ -1,0 +1,135 @@
+package node_test
+
+import (
+	"github.com/lhemerly/Constellation/node"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWorkerPoolNode_BasicProcessing(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-1", 2, 5)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("unexpected error creating worker pool: %v", err)
+	}
+	defer wp.Delete()
+
+	var processedCount int32
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		atomic.AddInt32(&processedCount, 1)
+		return append([]byte("processed: "), input...), nil
+	})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			res, err := wp.Process([]byte("data"))
+			if err != nil {
+				t.Errorf("unexpected error on process: %v", err)
+			}
+			if string(res) != "processed: data" {
+				t.Errorf("unexpected result: %s", string(res))
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if atomic.LoadInt32(&processedCount) != 5 {
+		t.Errorf("expected 5 processed, got %d", processedCount)
+	}
+}
+
+func TestWorkerPoolNode_QueueFull(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-full", 1, 1)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("unexpected error creating worker pool: %v", err)
+	}
+	defer wp.Delete()
+
+	// Slow down processing so queue backs up
+	blockChan := make(chan struct{})
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		<-blockChan
+		return []byte("done"), nil
+	})
+
+	// 1 takes the worker
+	go wp.Process([]byte("w1"))
+	time.Sleep(10 * time.Millisecond) // Ensure worker picks it up
+
+	// 1 takes the queue
+	errChan := make(chan error, 1)
+	go func() {
+		_, err := wp.Process([]byte("q1"))
+		errChan <- err
+	}()
+	time.Sleep(10 * time.Millisecond) // Ensure it gets queued
+
+	// 1 gets rejected (queue full)
+	_, err := wp.Process([]byte("reject"))
+	if err == nil {
+		t.Errorf("expected queue full error, got nil")
+	} else if err.Error() != "worker pool queue is full" {
+		t.Errorf("expected queue full error message, got: %v", err)
+	}
+
+	// Unblock workers
+	close(blockChan)
+	if err := <-errChan; err != nil {
+		t.Errorf("unexpected error on queued item: %v", err)
+	}
+}
+
+func TestWorkerPoolNode_DeleteShutsDownWorkers(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-del", 2, 2)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("unexpected error creating worker pool: %v", err)
+	}
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(50 * time.Millisecond)
+		return []byte("done"), nil
+	})
+
+	// Queue some jobs
+	var wg sync.WaitGroup
+	errChan := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := wp.Process([]byte("test"))
+			errChan <- err
+		}()
+	}
+
+	// Wait briefly so jobs get into the pool
+	time.Sleep(10 * time.Millisecond)
+
+	// Delete should wait for active workers, and return errors to the waiting queue (if any were stuck there, though here they are processing)
+	err := wp.Delete()
+	if err != nil {
+		t.Fatalf("unexpected error deleting worker pool: %v", err)
+	}
+
+	wg.Wait()
+	close(errChan)
+	for err := range errChan {
+		// they should succeed or fail cleanly, in this case they had enough time to start processing
+		// but if they were stuck in queue they'd get "node deleted before processing"
+		if err != nil && err.Error() != "node deleted before processing" && err.Error() != "node is shutting down while waiting for result" {
+			t.Errorf("unexpected error: %v", err)
+		}
+	}
+
+	// New process attempts should fail
+	_, err = wp.Process([]byte("new"))
+	if err == nil {
+		t.Fatalf("expected error processing after delete")
+	} else if err.Error() != "node is shutting down" {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}

--- a/node/worker_pool_node.go
+++ b/node/worker_pool_node.go
@@ -1,0 +1,134 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// WorkerPoolNode manages a fixed pool of background worker goroutines to process requests concurrently.
+// This limits the number of active `Process` calls that run concurrently and queues excess requests.
+type WorkerPoolNode struct {
+	*BaseNode
+	workers    int
+	queueSize  int
+	jobQueue   chan workerJob
+	ctx        context.Context
+	cancel     context.CancelFunc
+	workerWg   sync.WaitGroup
+}
+
+type workerJob struct {
+	input      []byte
+	resultChan chan workerResult
+}
+
+type workerResult struct {
+	output []byte
+	err    error
+}
+
+// NewWorkerPoolNode creates a new WorkerPoolNode with the specified number of workers and queue size.
+func NewWorkerPoolNode(id string, workers int, queueSize int) *WorkerPoolNode {
+	if workers <= 0 {
+		panic("WorkerPoolNode requires at least 1 worker")
+	}
+	if queueSize <= 0 {
+		panic("WorkerPoolNode requires a queue size of at least 1")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	wpNode := &WorkerPoolNode{
+		BaseNode:  NewBaseNode(id),
+		workers:   workers,
+		queueSize: queueSize,
+		jobQueue:  make(chan workerJob, queueSize),
+		ctx:       ctx,
+		cancel:    cancel,
+	}
+
+	// Override Process directly instead of using SetProcessFunc,
+	// so users can still set their own business logic via SetProcessFunc,
+	// while we handle the queuing mechanism around it.
+	return wpNode
+}
+
+// Create initializes the node and starts the background workers.
+func (wp *WorkerPoolNode) Create() error {
+	if err := wp.BaseNode.Create(); err != nil {
+		return err
+	}
+
+	for i := 0; i < wp.workers; i++ {
+		wp.workerWg.Add(1)
+		go wp.workerLoop()
+	}
+
+	return nil
+}
+
+// workerLoop continuously pulls jobs from the queue and processes them until context is canceled.
+func (wp *WorkerPoolNode) workerLoop() {
+	defer wp.workerWg.Done()
+
+	for {
+		select {
+		case <-wp.ctx.Done():
+			return
+		case job, ok := <-wp.jobQueue:
+			if !ok {
+				return
+			}
+			// Call the base node's Process to run the user's processFunc (with middlewares)
+			out, err := wp.BaseNode.Process(job.input)
+			job.resultChan <- workerResult{output: out, err: err}
+		}
+	}
+}
+
+// Process enqueues the input for processing by a worker.
+// Returns an error if the node is shutting down or the queue is full.
+func (wp *WorkerPoolNode) Process(input []byte) ([]byte, error) {
+	resultChan := make(chan workerResult, 1)
+	job := workerJob{
+		input:      input,
+		resultChan: resultChan,
+	}
+
+	// Try to enqueue the job, checking for context cancellation first
+	select {
+	case <-wp.ctx.Done():
+		return nil, errors.New("node is shutting down")
+	default:
+		select {
+		case <-wp.ctx.Done():
+			return nil, errors.New("node is shutting down")
+		case wp.jobQueue <- job:
+			// Wait for the result
+			select {
+			case <-wp.ctx.Done():
+				return nil, errors.New("node is shutting down while waiting for result")
+			case res := <-resultChan:
+				return res.output, res.err
+			}
+		default:
+			return nil, errors.New("worker pool queue is full")
+		}
+	}
+}
+
+// Delete cleanly shuts down the worker pool, waiting for active jobs to finish
+// and draining any queued requests.
+func (wp *WorkerPoolNode) Delete() error {
+	wp.cancel()     // Signal workers to stop accepting new jobs
+	wp.workerWg.Wait() // Wait for active workers to finish their current job
+
+	// Drain the remaining queue
+	close(wp.jobQueue)
+	for job := range wp.jobQueue {
+		job.resultChan <- workerResult{nil, errors.New("node deleted before processing")}
+	}
+
+	return wp.BaseNode.Delete()
+}


### PR DESCRIPTION
This PR introduces three new components to the `node` package:
1. `RateLimitMiddleware`: A token-bucket rate limiter that safely throttles excessive requests.
2. `WorkerPoolNode`: A concurrency-limiting node that spins up a fixed pool of background goroutines to process requests and queues the rest.
3. `ScatterGatherNode`: A fan-out node that requests multiple targets simultaneously and returns the first successful response, providing hedging for tail latency.

All features include unit tests checking for concurrency issues, context cancellation, and proper shutdown mechanics.

---
*PR created automatically by Jules for task [12861798185066110765](https://jules.google.com/task/12861798185066110765) started by @lhemerly*