### PR TITLE
docs: update file references in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
Fixed broken file references in `readme.md` for the Contribution guidelines and the License to point to the actual filenames in the repository (`CONTRIBUTE.md` and `LICENSE.md`). All other documented functionality was verified to exist in the codebase.

---
*PR created automatically by Jules for task [2813164620132708178](https://jules.google.com/task/2813164620132708178) started by @lhemerly*