### PR TITLE
feat: add new nodes and rate limit middleware

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +58,45 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimiterMiddleware limits the number of requests using a token bucket algorithm.
+func RateLimiterMiddleware(capacity int, refillRate time.Duration) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64 = float64(capacity)
+		lastRefill time.Time = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+
+			now := time.Now()
+			elapsed := now.Sub(lastRefill)
+
+			// Refill tokens
+			tokensToAdd := float64(elapsed) / float64(refillRate)
+			if tokensToAdd > 0 {
+				tokens += tokensToAdd
+				if tokens > float64(capacity) {
+					tokens = float64(capacity)
+				}
+				// Correctly advance lastRefill by the exact elapsed duration corresponding to the tokens added
+				// This prevents micro-drifts and fractional token accumulation bugs.
+				lastRefill = lastRefill.Add(time.Duration(tokensToAdd * float64(refillRate)))
+			}
+
+			if tokens >= 1 {
+				tokens--
+				mu.Unlock()
+				return next(input)
+			} else {
+				mu.Unlock()
+				return nil, ErrRateLimitExceeded
+			}
 		}
 	}
 }

--- a/node/pubsub_node.go
+++ b/node/pubsub_node.go
@@ -1,0 +1,126 @@
+package node
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+)
+
+// PubSubMessage is the structure expected by the PubSubNode for processing.
+type PubSubMessage struct {
+	Topic   string `json:"topic"`
+	Payload []byte `json:"payload"`
+}
+
+// PubSubNode allows nodes to subscribe to specific topics rather than receiving all notifications.
+type PubSubNode struct {
+	*BaseNode
+	topicSubs map[string]map[string]Node
+	mu        sync.RWMutex
+}
+
+// NewPubSubNode creates a new PubSubNode.
+func NewPubSubNode(id string) *PubSubNode {
+	psn := &PubSubNode{
+		BaseNode:  NewBaseNode(id),
+		topicSubs: make(map[string]map[string]Node),
+	}
+	psn.SetProcessFunc(psn.pubSubProcess)
+	return psn
+}
+
+// SubscribeTopic adds a node to the subscription list for a specific topic.
+func (psn *PubSubNode) SubscribeTopic(topic string, node Node) error {
+	psn.mu.Lock()
+	defer psn.mu.Unlock()
+
+	if _, exists := psn.topicSubs[topic]; !exists {
+		psn.topicSubs[topic] = make(map[string]Node)
+	}
+	psn.topicSubs[topic][node.GetID()] = node
+
+	// Also subscribe to the BaseNode to keep general track, though we route by topic
+	return psn.BaseNode.Subscribe(node)
+}
+
+// UnsubscribeTopic removes a node from the subscription list for a specific topic.
+func (psn *PubSubNode) UnsubscribeTopic(topic string, node Node) error {
+	psn.mu.Lock()
+	defer psn.mu.Unlock()
+
+	if subs, exists := psn.topicSubs[topic]; exists {
+		delete(subs, node.GetID())
+		if len(subs) == 0 {
+			delete(psn.topicSubs, topic)
+		}
+	}
+
+	return psn.BaseNode.Unsubscribe(node)
+}
+
+// Publish sends an event to all nodes subscribed to a specific topic.
+func (psn *PubSubNode) Publish(topic string, payload []byte) error {
+	msg := PubSubMessage{
+		Topic:   topic,
+		Payload: payload,
+	}
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	_, err = psn.Process(data)
+	return err
+}
+
+// pubSubProcess handles routing the input to the appropriate topic subscribers.
+// The input must be a JSON-encoded PubSubMessage.
+func (psn *PubSubNode) pubSubProcess(input []byte) ([]byte, error) {
+	var msg PubSubMessage
+	if err := json.Unmarshal(input, &msg); err != nil {
+		return nil, errors.New("invalid pubsub message format")
+	}
+
+	psn.mu.RLock()
+	subsForTopic, exists := psn.topicSubs[msg.Topic]
+	if !exists {
+		psn.mu.RUnlock()
+		return nil, nil // No subscribers for this topic, drop silently or could return an error
+	}
+
+	// Copy subscribers to avoid holding lock during processing
+	targets := make([]Node, 0, len(subsForTopic))
+	for _, sub := range subsForTopic {
+		targets = append(targets, sub)
+	}
+	psn.mu.RUnlock()
+
+	var wg sync.WaitGroup
+	var errs []error
+	var errMu sync.Mutex
+
+	for _, target := range targets {
+		wg.Add(1)
+		go func(t Node) {
+			defer wg.Done()
+
+			// Clone payload to prevent data races
+			payloadCopy := make([]byte, len(msg.Payload))
+			copy(payloadCopy, msg.Payload)
+
+			_, err := t.Process(payloadCopy)
+			if err != nil {
+				errMu.Lock()
+				errs = append(errs, err)
+				errMu.Unlock()
+			}
+		}(target)
+	}
+
+	wg.Wait()
+
+	if len(errs) > 0 {
+		return nil, errors.Join(append([]error{errors.New("some topic subscribers failed")}, errs...)...)
+	}
+
+	return nil, nil
+}

--- a/node/scatter_gather_node.go
+++ b/node/scatter_gather_node.go
@@ -1,0 +1,172 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ScatterGatherNode implements the scatter-gather pattern. It scatters a single
+// input to multiple targets concurrently and gathers successful results until
+// a specified quorum is reached, or a timeout occurs.
+type ScatterGatherNode struct {
+	*BaseNode
+	targets []Node
+	quorum  int
+	timeout time.Duration
+}
+
+// NewScatterGatherNode creates a new ScatterGatherNode.
+func NewScatterGatherNode(id string, targets []Node, quorum int, timeout time.Duration) *ScatterGatherNode {
+	if len(targets) == 0 {
+		panic("ScatterGatherNode requires at least one target")
+	}
+	if quorum <= 0 || quorum > len(targets) {
+		panic("ScatterGatherNode requires quorum > 0 and <= len(targets)")
+	}
+
+	sgn := &ScatterGatherNode{
+		BaseNode: NewBaseNode(id),
+		targets:  targets,
+		quorum:   quorum,
+		timeout:  timeout,
+	}
+
+	sgn.SetProcessFunc(sgn.scatterGatherProcess)
+	return sgn
+}
+
+// scatterGatherProcess handles the scatter-gather logic.
+func (sgn *ScatterGatherNode) scatterGatherProcess(input []byte) ([]byte, error) {
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		errs    []error
+		results [][]byte
+	)
+
+	// Context for cancellation
+	ctx, cancel := context.WithTimeout(context.Background(), sgn.timeout)
+	defer cancel()
+
+	resultChan := make(chan []byte, len(sgn.targets))
+	errChan := make(chan error, len(sgn.targets))
+
+	// Scatter
+	for _, target := range sgn.targets {
+		wg.Add(1)
+		go func(t Node) {
+			defer wg.Done()
+
+			// Check for cancellation before processing
+			select {
+			case <-ctx.Done():
+				errChan <- ctx.Err()
+				return
+			default:
+			}
+
+			// Clone input to prevent data races
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			res, err := t.Process(inputCopy)
+			if err != nil {
+				errChan <- err
+			} else {
+				resultChan <- res
+			}
+		}(target)
+	}
+
+	// Wait for all workers in a background goroutine to close channels
+	doneChan := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneChan)
+		close(resultChan)
+		close(errChan)
+	}()
+
+	// Gather
+	for {
+		select {
+		case res, ok := <-resultChan:
+			if !ok {
+				resultChan = nil
+				break
+			}
+			mu.Lock()
+			results = append(results, res)
+			if len(results) >= sgn.quorum {
+				cancel() // Stop remaining workers
+				mu.Unlock()
+				return sgn.combineResults(results), nil
+			}
+			mu.Unlock()
+		case err, ok := <-errChan:
+			if !ok {
+				errChan = nil
+				break
+			}
+			mu.Lock()
+			errs = append(errs, err)
+			mu.Unlock()
+		case <-doneChan:
+			mu.Lock()
+			defer mu.Unlock()
+			if len(results) >= sgn.quorum {
+				return sgn.combineResults(results), nil
+			}
+			return nil, errors.Join(append([]error{errors.New("scatter-gather failed to reach quorum")}, errs...)...)
+		case <-ctx.Done():
+			mu.Lock()
+			defer mu.Unlock()
+			if len(results) >= sgn.quorum {
+				return sgn.combineResults(results), nil
+			}
+			return nil, errors.Join(append([]error{errors.New("scatter-gather timeout")}, errs...)...)
+		}
+	}
+}
+
+func (sgn *ScatterGatherNode) combineResults(results [][]byte) []byte {
+	// Simple concatenation for now, similar to MapReduceNode
+	var combined []byte
+	for _, res := range results {
+		combined = append(combined, res...)
+	}
+	return combined
+}
+
+// Create initializes the scatter-gather node and its dependencies.
+func (sgn *ScatterGatherNode) Create() error {
+	if err := sgn.BaseNode.Create(); err != nil {
+		return err
+	}
+	for _, t := range sgn.targets {
+		if err := t.Create(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Delete cleans up the scatter-gather node and its dependencies.
+func (sgn *ScatterGatherNode) Delete() error {
+	var errs []error
+	if err := sgn.BaseNode.Delete(); err != nil {
+		errs = append(errs, err)
+	}
+	for _, t := range sgn.targets {
+		if err := t.Delete(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}

--- a/node/tests/pubsub_node_test.go
+++ b/node/tests/pubsub_node_test.go
@@ -1,0 +1,123 @@
+package node_test
+
+import (
+	"encoding/json"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestPubSubNode_Publish(t *testing.T) {
+	psn := node.NewPubSubNode("pubsub")
+
+	var sub1Received int32
+	sub1 := node.NewBaseNode("sub1")
+	sub1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		atomic.AddInt32(&sub1Received, 1)
+		return nil, nil
+	})
+
+	var sub2Received int32
+	sub2 := node.NewBaseNode("sub2")
+	sub2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		atomic.AddInt32(&sub2Received, 1)
+		return nil, nil
+	})
+
+	err := psn.SubscribeTopic("news", sub1)
+	if err != nil {
+		t.Fatalf("Failed to subscribe: %v", err)
+	}
+
+	err = psn.SubscribeTopic("sports", sub2)
+	if err != nil {
+		t.Fatalf("Failed to subscribe: %v", err)
+	}
+
+	err = psn.SubscribeTopic("news", sub2) // sub2 listens to news and sports
+	if err != nil {
+		t.Fatalf("Failed to subscribe: %v", err)
+	}
+
+	err = psn.Publish("news", []byte("breaking news"))
+	if err != nil {
+		t.Fatalf("Failed to publish: %v", err)
+	}
+
+	if atomic.LoadInt32(&sub1Received) != 1 {
+		t.Errorf("Expected sub1 to receive 1 news event, got %d", sub1Received)
+	}
+	if atomic.LoadInt32(&sub2Received) != 1 {
+		t.Errorf("Expected sub2 to receive 1 news event, got %d", sub2Received)
+	}
+
+	err = psn.Publish("sports", []byte("game over"))
+	if err != nil {
+		t.Fatalf("Failed to publish: %v", err)
+	}
+
+	if atomic.LoadInt32(&sub1Received) != 1 {
+		t.Errorf("Expected sub1 to still have 1 event, got %d", sub1Received)
+	}
+	if atomic.LoadInt32(&sub2Received) != 2 {
+		t.Errorf("Expected sub2 to have 2 events total, got %d", sub2Received)
+	}
+
+	err = psn.UnsubscribeTopic("news", sub2)
+	if err != nil {
+		t.Fatalf("Failed to unsubscribe: %v", err)
+	}
+
+	err = psn.Publish("news", []byte("more news"))
+	if err != nil {
+		t.Fatalf("Failed to publish: %v", err)
+	}
+
+	if atomic.LoadInt32(&sub1Received) != 2 {
+		t.Errorf("Expected sub1 to have 2 events, got %d", sub1Received)
+	}
+	if atomic.LoadInt32(&sub2Received) != 2 {
+		t.Errorf("Expected sub2 to still have 2 events, got %d", sub2Received)
+	}
+}
+
+func TestPubSubNode_InvalidMessage(t *testing.T) {
+	psn := node.NewPubSubNode("pubsub")
+	_, err := psn.Process([]byte("not valid json"))
+	if err == nil {
+		t.Fatal("Expected error on invalid json")
+	}
+	if !strings.Contains(err.Error(), "invalid pubsub message format") {
+		t.Errorf("Unexpected error message: %v", err)
+	}
+}
+
+func TestPubSubNode_Process(t *testing.T) {
+	psn := node.NewPubSubNode("pubsub")
+
+	var sub1Received int32
+	sub1 := node.NewBaseNode("sub1")
+	sub1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		atomic.AddInt32(&sub1Received, 1)
+		return nil, nil
+	})
+
+	_ = psn.SubscribeTopic("events", sub1)
+
+	msg := node.PubSubMessage{
+		Topic:   "events",
+		Payload: []byte("payload"),
+	}
+	data, _ := json.Marshal(msg)
+
+	_, err := psn.Process(data)
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	if atomic.LoadInt32(&sub1Received) != 1 {
+		t.Errorf("Expected sub1 to receive 1 event via Process, got %d", sub1Received)
+	}
+}

--- a/node/tests/rate_limiter_middleware_test.go
+++ b/node/tests/rate_limiter_middleware_test.go
@@ -1,0 +1,45 @@
+package node_test
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestRateLimiterMiddleware_TokensAccumulation(t *testing.T) {
+	n := node.NewBaseNode("target")
+
+	var processed int32
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		atomic.AddInt32(&processed, 1)
+		return []byte("ok"), nil
+	})
+
+	// Capacity of 5, refill 1 token every 100ms
+	n.Use(node.RateLimiterMiddleware(5, 100*time.Millisecond))
+
+	n.Create()
+
+	// Exhaust the initial 5 tokens
+	for i := 0; i < 5; i++ {
+		_, err := n.Process([]byte("input"))
+		if err != nil {
+			t.Fatalf("Expected initial request to succeed, got %v", err)
+		}
+	}
+
+	// Wait just a tiny bit, not enough for a full token
+	time.Sleep(10 * time.Millisecond)
+
+	// Send many requests very fast
+	for i := 0; i < 100; i++ {
+		_, err := n.Process([]byte("input"))
+		if err == nil {
+			t.Fatalf("Expected fast requests to fail rate limit, got success on request %d", i)
+		}
+	}
+
+	n.Delete()
+}

--- a/node/tests/scatter_gather_node_test.go
+++ b/node/tests/scatter_gather_node_test.go
@@ -1,0 +1,100 @@
+package node_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestScatterGatherNode_Success(t *testing.T) {
+	n1 := node.NewBaseNode("target1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("res1"), nil
+	})
+
+	n2 := node.NewBaseNode("target2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("res2"), nil
+	})
+
+	n3 := node.NewBaseNode("target3")
+	n3.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond) // slow target
+		return []byte("res3"), nil
+	})
+
+	sgn := node.NewScatterGatherNode("sg", []node.Node{n1, n2, n3}, 2, 500*time.Millisecond)
+
+	err := sgn.Create()
+	if err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+
+	output, err := sgn.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("Process failed: %v", err)
+	}
+
+	outStr := string(output)
+	// Quorum is 2, so it should return res1+res2 or res2+res1
+	if !strings.Contains(outStr, "res1") || !strings.Contains(outStr, "res2") {
+		t.Errorf("Unexpected output: %s", outStr)
+	}
+	if strings.Contains(outStr, "res3") {
+		t.Errorf("Output should not contain res3 since quorum of 2 was reached early")
+	}
+
+	err = sgn.Delete()
+	if err != nil {
+		t.Fatalf("Failed to delete node: %v", err)
+	}
+}
+
+func TestScatterGatherNode_FailureNoQuorum(t *testing.T) {
+	n1 := node.NewBaseNode("target1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("fail1")
+	})
+
+	n2 := node.NewBaseNode("target2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("fail2")
+	})
+
+	sgn := node.NewScatterGatherNode("sg", []node.Node{n1, n2}, 1, 500*time.Millisecond)
+
+	_, err := sgn.Process([]byte("input"))
+	if err == nil {
+		t.Fatal("Expected error due to failure to reach quorum")
+	}
+	if !strings.Contains(err.Error(), "scatter-gather failed to reach quorum") {
+		t.Errorf("Unexpected error message: %v", err)
+	}
+}
+
+func TestScatterGatherNode_Timeout(t *testing.T) {
+	n1 := node.NewBaseNode("target1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(200 * time.Millisecond)
+		return []byte("res1"), nil
+	})
+
+	n2 := node.NewBaseNode("target2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(200 * time.Millisecond)
+		return []byte("res2"), nil
+	})
+
+	sgn := node.NewScatterGatherNode("sg", []node.Node{n1, n2}, 2, 50*time.Millisecond)
+
+	_, err := sgn.Process([]byte("input"))
+	if err == nil {
+		t.Fatal("Expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "scatter-gather timeout") {
+		t.Errorf("Unexpected error message: %v", err)
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,8 @@ The `node` package provides abstractions for creating and managing nodes within 
 - Data Processing
 - Subscription Management
 - Event Notification
-- **Advanced Node Types**: Includes `FailoverNode` (primary/secondary logic), `LoadBalancerNode` (round-robin distribution), `PipelineNode` (sequential stage processing), `RouterNode` (conditional message routing), and `MapReduceNode` (parallel mappers and a single reducer).
-- **Middlewares**: Supports composing node processing chains with middlewares such as `LoggingMiddleware`, `RetryMiddleware`, `RecoveryMiddleware`, `CacheMiddleware`, `TimeoutMiddleware`, and `CircuitBreakerMiddleware`.
+- **Advanced Node Types**: Includes `FailoverNode` (primary/secondary logic), `LoadBalancerNode` (round-robin distribution), `PipelineNode` (sequential stage processing), `RouterNode` (conditional message routing), `MapReduceNode` (parallel mappers and a single reducer), `ScatterGatherNode` (parallel broadcast with quorum gathering), and `PubSubNode` (topic-based publish/subscribe capabilities).
+- **Middlewares**: Supports composing node processing chains with middlewares such as `LoggingMiddleware`, `RetryMiddleware`, `RecoveryMiddleware`, `CacheMiddleware`, `TimeoutMiddleware`, `CircuitBreakerMiddleware`, and `RateLimiterMiddleware`.
 
 ### 2. Connection Package
 


### PR DESCRIPTION
Adds `PubSubNode` for topic-based publish/subscribe capabilities, `ScatterGatherNode` for parallel broadcast with quorum gathering, and `RateLimiterMiddleware` to node processing chain to limit request rates using a token bucket algorithm. Updates README and tests.

---
*PR created automatically by Jules for task [1869793019137084548](https://jules.google.com/task/1869793019137084548) started by @lhemerly*