### PR TITLE
Fix file references in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
Fixes `CONTRIBUTING.md` and `LICENSE` file names referencing them as `CONTRIBUTE.md` and `LICENSE.md` in `readme.md`. I also verified against the codebase and found no discrepancy regarding missing functionalities mentioned in `readme.md`.

---
*PR created automatically by Jules for task [11197421416384435746](https://jules.google.com/task/11197421416384435746) started by @lhemerly*