### PR TITLE
docs: update readme to fix incorrect filenames

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
After reviewing the codebase against the `readme.md`, I confirmed that all listed functionality is present.
- `FailoverNode`, `LoadBalancerNode`, `PipelineNode`, `RouterNode`, and `MapReduceNode` exist in `node/`.
- Middlewares `LoggingMiddleware`, `RetryMiddleware`, `RecoveryMiddleware`, `CacheMiddleware`, `TimeoutMiddleware`, and `CircuitBreakerMiddleware` exist in `node/middlewares.go`.
- Connection implementations `ChannelConnection` and `GRPCConnection` exist.
- Event dispatchers `EventDispatcher` and `StreamEventDispatcher` exist.

I noticed that two filenames were incorrectly referenced in the readme:
- `CONTRIBUTING.md` was referenced, but the file is `CONTRIBUTE.md`.
- `LICENSE` was referenced, but the file is `LICENSE.md`.
I updated the references to match the repository. No missing functionality was found.

---
*PR created automatically by Jules for task [17307736481068456826](https://jules.google.com/task/17307736481068456826) started by @lhemerly*