### PR TITLE
feat(nodes): add creative concurrent nodes and rate limit middleware

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +58,43 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimitMiddleware limits the number of requests processed per second using a token bucket.
+func RateLimitMiddleware(capacity int, refillRate float64) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64 = float64(capacity)
+		lastRefill time.Time = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+
+			now := time.Now()
+			elapsed := now.Sub(lastRefill).Seconds()
+			tokensToAdd := elapsed * refillRate
+
+			if tokensToAdd > 0 {
+				tokens += tokensToAdd
+				if tokens > float64(capacity) {
+					tokens = float64(capacity)
+				}
+				// Add the exact duration for the accrued tokens to prevent micro-drifts
+				lastRefill = lastRefill.Add(time.Duration(tokensToAdd / refillRate * float64(time.Second)))
+			}
+
+			if tokens >= 1.0 {
+				tokens -= 1.0
+				mu.Unlock()
+				return next(input)
+			}
+
+			mu.Unlock()
+			return nil, ErrRateLimitExceeded
 		}
 	}
 }

--- a/node/scatter_gather_node.go
+++ b/node/scatter_gather_node.go
@@ -1,0 +1,180 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	ErrScatterGatherTimeout = errors.New("scatter-gather timeout reached before quorum")
+	ErrScatterGatherFailed  = errors.New("scatter-gather total failure")
+)
+
+// ScatterGatherNode sends an input request to multiple target nodes concurrently
+// and waits for responses until a specific timeout is reached or a required number
+// of successful responses (quorum) are collected.
+type ScatterGatherNode struct {
+	*BaseNode
+	targets []Node
+	timeout time.Duration
+	quorum  int
+}
+
+// NewScatterGatherNode creates a new ScatterGatherNode.
+func NewScatterGatherNode(id string, targets []Node, timeout time.Duration, quorum int) *ScatterGatherNode {
+	if quorum > len(targets) {
+		quorum = len(targets)
+	}
+
+	sg := &ScatterGatherNode{
+		BaseNode: NewBaseNode(id),
+		targets:  targets,
+		timeout:  timeout,
+		quorum:   quorum,
+	}
+
+	sg.SetProcessFunc(sg.scatterGatherProcess)
+	return sg
+}
+
+// Create initializes the scatter-gather node and its targets.
+func (sg *ScatterGatherNode) Create() error {
+	if err := sg.BaseNode.Create(); err != nil {
+		return err
+	}
+	for _, t := range sg.targets {
+		if err := t.Create(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Delete cleans up the scatter-gather node and its targets.
+func (sg *ScatterGatherNode) Delete() error {
+	var errs []error
+	if err := sg.BaseNode.Delete(); err != nil {
+		errs = append(errs, err)
+	}
+	for _, t := range sg.targets {
+		if err := t.Delete(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+// scatterGatherProcess handles the dispatching and gathering.
+func (sg *ScatterGatherNode) scatterGatherProcess(input []byte) ([]byte, error) {
+	if len(sg.targets) == 0 {
+		return nil, errors.New("no targets configured for scatter-gather")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), sg.timeout)
+	defer cancel()
+
+	resultChan := make(chan []byte, len(sg.targets))
+	errChan := make(chan error, len(sg.targets))
+	var wg sync.WaitGroup
+
+	for _, target := range sg.targets {
+		wg.Add(1)
+		go func(t Node) {
+			defer wg.Done()
+
+			// Clone input to prevent data races
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			res, err := t.Process(inputCopy)
+			if err != nil {
+				errChan <- err
+			} else {
+				resultChan <- res
+			}
+		}(target)
+	}
+
+	// Channel to signal when all workers are done (so we don't block on timeout
+	// if everything finishes or fails early).
+	doneChan := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneChan)
+	}()
+
+	var finalOutput []byte
+	var collectedErrs []error
+	var successfulResponses int
+
+	// Wait loop
+	for {
+		// Stop if we hit quorum
+		if successfulResponses >= sg.quorum && sg.quorum > 0 {
+			return finalOutput, nil
+		}
+
+		select {
+		case res := <-resultChan:
+			successfulResponses++
+			// Concatenate successful responses
+			finalOutput = append(finalOutput, res...)
+		case <-ctx.Done():
+			// Timeout reached.
+			// Drain any remaining successful responses before declaring complete failure
+			// just in case they arrived right as context was cancelled.
+		drainLoop:
+			for {
+				select {
+				case res := <-resultChan:
+					successfulResponses++
+					finalOutput = append(finalOutput, res...)
+				default:
+					break drainLoop
+				}
+			}
+
+			if successfulResponses > 0 {
+				return finalOutput, nil
+			}
+
+			// If no successes, gather errors without blocking
+		errDrainLoop:
+			for {
+				select {
+				case e := <-errChan:
+					collectedErrs = append(collectedErrs, e)
+				default:
+					break errDrainLoop
+				}
+			}
+			return nil, errors.Join(append([]error{ErrScatterGatherTimeout}, collectedErrs...)...)
+
+		case <-doneChan:
+			// All workers finished. Let's drain remaining results/errors.
+		finishLoop:
+			for {
+				select {
+				case res := <-resultChan:
+					successfulResponses++
+					finalOutput = append(finalOutput, res...)
+				case e := <-errChan:
+					collectedErrs = append(collectedErrs, e)
+				default:
+					break finishLoop
+				}
+			}
+
+			if successfulResponses > 0 {
+				return finalOutput, nil
+			}
+			return nil, errors.Join(append([]error{ErrScatterGatherFailed}, collectedErrs...)...)
+		}
+	}
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -314,3 +314,56 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
 	}
 }
+
+func TestMiddlewares_RateLimit(t *testing.T) {
+	n := node.NewBaseNode("rate-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// Capacity 2, refill rate 10 per second (1 token every 100ms)
+	n.Use(node.RateLimitMiddleware(2, 10.0))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	// 1. Consume all initial tokens
+	res, err := n.Process([]byte("req1"))
+	if err != nil {
+		t.Fatalf("expected req1 to succeed, got %v", err)
+	}
+	if string(res) != "success" {
+		t.Errorf("expected success, got %s", string(res))
+	}
+
+	res, err = n.Process([]byte("req2"))
+	if err != nil {
+		t.Fatalf("expected req2 to succeed, got %v", err)
+	}
+	if string(res) != "success" {
+		t.Errorf("expected success, got %s", string(res))
+	}
+
+	// 2. Exceed capacity, should be rate limited
+	_, err = n.Process([]byte("req3"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// 3. Wait for enough time to accrue at least 1 token (100ms + some buffer)
+	time.Sleep(150 * time.Millisecond)
+
+	// 4. Request should succeed again
+	res, err = n.Process([]byte("req4"))
+	if err != nil {
+		t.Fatalf("expected req4 to succeed, got %v", err)
+	}
+	if string(res) != "success" {
+		t.Errorf("expected success, got %s", string(res))
+	}
+
+	// 5. Following request should fail again as only 1 token was added
+	_, err = n.Process([]byte("req5"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+}

--- a/node/tests/scatter_gather_node_test.go
+++ b/node/tests/scatter_gather_node_test.go
@@ -1,0 +1,146 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"testing"
+	"time"
+)
+
+func TestScatterGatherNode_Success(t *testing.T) {
+	n1 := node.NewBaseNode("t1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+
+	n2 := node.NewBaseNode("t2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+
+	sg := node.NewScatterGatherNode("sg", []node.Node{n1, n2}, 1*time.Second, 2)
+	defer cleanupNodes(t, []node.Node{sg}) // SG Delete cleans targets
+
+	if err := sg.Create(); err != nil {
+		t.Fatalf("failed to create: %v", err)
+	}
+
+	res, err := sg.Process([]byte("test"))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	out := string(res)
+	if out != "AB" && out != "BA" {
+		t.Errorf("expected AB or BA, got %s", out)
+	}
+}
+
+func TestScatterGatherNode_QuorumReachedEarly(t *testing.T) {
+	n1 := node.NewBaseNode("t1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+
+	n2 := node.NewBaseNode("t2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(500 * time.Millisecond) // slow
+		return []byte("B"), nil
+	})
+
+	// Quorum is 1, so it shouldn't wait for n2
+	sg := node.NewScatterGatherNode("sg-quorum", []node.Node{n1, n2}, 1*time.Second, 1)
+	defer cleanupNodes(t, []node.Node{sg})
+
+	if err := sg.Create(); err != nil {
+		t.Fatalf("failed to create: %v", err)
+	}
+
+	start := time.Now()
+	res, err := sg.Process([]byte("test"))
+	dur := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if string(res) != "A" {
+		t.Errorf("expected A, got %s", string(res))
+	}
+	if dur > 100*time.Millisecond {
+		t.Errorf("expected fast return, took %v", dur)
+	}
+}
+
+func TestScatterGatherNode_Timeout(t *testing.T) {
+	n1 := node.NewBaseNode("t1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(200 * time.Millisecond)
+		return []byte("A"), nil
+	})
+
+	sg := node.NewScatterGatherNode("sg-timeout", []node.Node{n1}, 50*time.Millisecond, 1)
+	defer cleanupNodes(t, []node.Node{sg})
+
+	if err := sg.Create(); err != nil {
+		t.Fatalf("failed to create: %v", err)
+	}
+
+	_, err := sg.Process([]byte("test"))
+	if !errors.Is(err, node.ErrScatterGatherTimeout) {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+}
+
+func TestScatterGatherNode_PartialSuccess(t *testing.T) {
+	n1 := node.NewBaseNode("t1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+
+	n2 := node.NewBaseNode("t2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("failed")
+	})
+
+	// Timeout should not be reached since both complete, but we only need quorum 1 or more.
+	// Since 1 succeeds, it should return that output and not fail, even if n2 failed.
+	// If quorum is 2, it won't be met, but all finish, so it will return what it got if successfulResponses > 0
+	sg := node.NewScatterGatherNode("sg-partial", []node.Node{n1, n2}, 1*time.Second, 2)
+	defer cleanupNodes(t, []node.Node{sg})
+
+	if err := sg.Create(); err != nil {
+		t.Fatalf("failed to create: %v", err)
+	}
+
+	res, err := sg.Process([]byte("test"))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if string(res) != "A" {
+		t.Errorf("expected A, got %s", string(res))
+	}
+}
+
+func TestScatterGatherNode_TotalFailure(t *testing.T) {
+	n1 := node.NewBaseNode("t1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("err1")
+	})
+
+	n2 := node.NewBaseNode("t2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("err2")
+	})
+
+	sg := node.NewScatterGatherNode("sg-fail", []node.Node{n1, n2}, 1*time.Second, 2)
+	defer cleanupNodes(t, []node.Node{sg})
+
+	if err := sg.Create(); err != nil {
+		t.Fatalf("failed to create: %v", err)
+	}
+
+	_, err := sg.Process([]byte("test"))
+	if !errors.Is(err, node.ErrScatterGatherFailed) {
+		t.Fatalf("expected ErrScatterGatherFailed, got %v", err)
+	}
+}

--- a/node/tests/worker_pool_node_test.go
+++ b/node/tests/worker_pool_node_test.go
@@ -1,0 +1,180 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWorkerPoolNode_Basic(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-node", 2, 5)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{wp})
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("processed: "), input...), nil
+	})
+
+	res, err := wp.Process([]byte("data"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(res) != "processed: data" {
+		t.Errorf("expected processed: data, got %s", string(res))
+	}
+}
+
+func TestWorkerPoolNode_ConcurrencyLimit(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-concurrent", 2, 10)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{wp})
+
+	var activeWorkers int32
+	var maxActiveWorkers int32
+	var mu sync.Mutex
+
+	blockCh := make(chan struct{})
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		current := atomic.AddInt32(&activeWorkers, 1)
+
+		mu.Lock()
+		if current > maxActiveWorkers {
+			maxActiveWorkers = current
+		}
+		mu.Unlock()
+
+		<-blockCh // block until released
+
+		atomic.AddInt32(&activeWorkers, -1)
+		return []byte("done"), nil
+	})
+
+	// Dispatch 5 jobs concurrently
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = wp.Process([]byte("test"))
+		}()
+	}
+
+	// Give them time to be picked up
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	maxWorkers := maxActiveWorkers
+	mu.Unlock()
+
+	if maxWorkers != 2 {
+		t.Errorf("expected max active workers to be 2, got %d", maxWorkers)
+	}
+
+	// Release all blocked workers
+	close(blockCh)
+
+	// Wait for all jobs to finish
+	wg.Wait()
+}
+
+func TestWorkerPoolNode_QueueFull(t *testing.T) {
+	// 1 worker, queue size 1
+	wp := node.NewWorkerPoolNode("wp-queue-full", 1, 1)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	blockCh := make(chan struct{})
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		<-blockCh
+		return []byte("done"), nil
+	})
+
+	// Job 1: taken by the 1 worker
+	go wp.Process([]byte("job1"))
+
+	// Job 2: sits in the queue (size 1)
+	time.Sleep(50 * time.Millisecond) // Give worker time to pick up Job 1
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, err := wp.Process([]byte("job2"))
+		if err != nil {
+			t.Errorf("expected job2 to succeed, got %v", err)
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond) // Give Job 2 time to queue
+
+	// Job 3: should fail immediately with queue full error
+	_, err := wp.Process([]byte("job3"))
+	if !errors.Is(err, node.ErrWorkerPoolQueueFull) {
+		t.Fatalf("expected ErrWorkerPoolQueueFull, got %v", err)
+	}
+
+	// Cleanup
+	close(blockCh)
+	wg.Wait()
+	if err := wp.Delete(); err != nil {
+		t.Fatalf("failed to delete node: %v", err)
+	}
+}
+
+func TestWorkerPoolNode_GracefulShutdown(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-shutdown", 1, 5)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	blockCh := make(chan struct{})
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		<-blockCh
+		return []byte("done"), nil
+	})
+
+	// Dispatch job 1 (taken by worker)
+	go wp.Process([]byte("job1"))
+	time.Sleep(50 * time.Millisecond)
+
+	// Dispatch job 2 (queued)
+	var errJob2 error
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, errJob2 = wp.Process([]byte("job2"))
+	}()
+	time.Sleep(50 * time.Millisecond)
+
+	// Start shutdown
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		close(blockCh) // unblock worker so it can exit
+	}()
+
+	if err := wp.Delete(); err != nil {
+		t.Fatalf("failed to delete node: %v", err)
+	}
+	wg.Wait()
+
+	// Job 2 should have been drained and returned ErrWorkerPoolDeleted
+	if !errors.Is(errJob2, node.ErrWorkerPoolDeleted) {
+		t.Fatalf("expected queued job to return ErrWorkerPoolDeleted during shutdown, got %v", errJob2)
+	}
+
+	// New requests after delete should fail immediately
+	_, err := wp.Process([]byte("job3"))
+	if !errors.Is(err, node.ErrWorkerPoolDeleted) {
+		t.Fatalf("expected ErrWorkerPoolDeleted for new requests after delete, got %v", err)
+	}
+}

--- a/node/worker_pool_node.go
+++ b/node/worker_pool_node.go
@@ -1,0 +1,147 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+var (
+	ErrWorkerPoolQueueFull = errors.New("worker pool queue is full")
+	ErrWorkerPoolDeleted   = errors.New("worker pool deleted")
+)
+
+type poolJob struct {
+	input      []byte
+	resultChan chan poolResult
+	ctx        context.Context
+}
+
+type poolResult struct {
+	output []byte
+	err    error
+}
+
+// WorkerPoolNode manages a pool of worker goroutines to process requests concurrently,
+// up to a specified limit. Requests that exceed the queue capacity return an error immediately.
+type WorkerPoolNode struct {
+	*BaseNode
+	numWorkers int
+	queueSize  int
+	jobQueue   chan poolJob
+	wg         sync.WaitGroup
+	ctx        context.Context
+	cancel     context.CancelFunc
+}
+
+// NewWorkerPoolNode creates a new WorkerPoolNode.
+func NewWorkerPoolNode(id string, numWorkers, queueSize int) *WorkerPoolNode {
+	ctx, cancel := context.WithCancel(context.Background())
+	wp := &WorkerPoolNode{
+		BaseNode:   NewBaseNode(id),
+		numWorkers: numWorkers,
+		queueSize:  queueSize,
+		jobQueue:   make(chan poolJob, queueSize),
+		ctx:        ctx,
+		cancel:     cancel,
+	}
+
+	return wp
+}
+
+// Create initializes the node and starts the worker pool.
+func (wp *WorkerPoolNode) Create() error {
+	if err := wp.BaseNode.Create(); err != nil {
+		return err
+	}
+
+	for i := 0; i < wp.numWorkers; i++ {
+		wp.wg.Add(1)
+		go wp.worker()
+	}
+	return nil
+}
+
+// Delete shuts down the node, cancels the workers, and drains the queue.
+func (wp *WorkerPoolNode) Delete() error {
+	var errs []error
+	if err := wp.BaseNode.Delete(); err != nil {
+		errs = append(errs, err)
+	}
+
+	// Signal workers to exit
+	wp.cancel()
+
+	// Wait for all workers to finish
+	wp.wg.Wait()
+
+	// Drain remaining jobs in the queue
+drainLoop:
+	for {
+		select {
+		case job := <-wp.jobQueue:
+			job.resultChan <- poolResult{nil, ErrWorkerPoolDeleted}
+		default:
+			break drainLoop
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+// worker runs continuously, picking up jobs from the queue until the context is canceled.
+func (wp *WorkerPoolNode) worker() {
+	defer wp.wg.Done()
+
+	for {
+		select {
+		case <-wp.ctx.Done():
+			return
+		case job := <-wp.jobQueue:
+			// Check if the individual job context is already done
+			if job.ctx != nil && job.ctx.Err() != nil {
+				job.resultChan <- poolResult{nil, job.ctx.Err()}
+				continue
+			}
+
+			// Process via BaseNode to handle custom SetProcessFunc and middlewares
+			res, err := wp.BaseNode.Process(job.input)
+			job.resultChan <- poolResult{res, err}
+		}
+	}
+}
+
+// Process overrides the BaseNode Process method to queue the input for the worker pool.
+func (wp *WorkerPoolNode) Process(input []byte) ([]byte, error) {
+	// First check if the pool is already deleted
+	select {
+	case <-wp.ctx.Done():
+		return nil, ErrWorkerPoolDeleted
+	default:
+	}
+
+	// Create job and enqueue
+	resultChan := make(chan poolResult, 1)
+	job := poolJob{
+		input:      input,
+		resultChan: resultChan,
+		ctx:        context.Background(),
+	}
+
+	select {
+	case wp.jobQueue <- job:
+	default:
+		return nil, ErrWorkerPoolQueueFull
+	}
+
+	// Wait for result or pool deletion
+	select {
+	case res := <-resultChan:
+		return res.output, res.err
+	case <-wp.ctx.Done():
+		return nil, ErrWorkerPoolDeleted
+	}
+}


### PR DESCRIPTION
## 💡 What
Introduces three new advanced components to the Constellation node and middleware suite:
- `RateLimitMiddleware`
- `WorkerPoolNode`
- `ScatterGatherNode`

## 🎯 Why
To fulfill a request for highly creative, unrestricted framework enhancements. These components unlock major capabilities for users building complex networked topologies:
- **Rate limiting** protects upstream servers or APIs from bursts.
- **Worker pools** bound the memory footprint and CPU load for heavy node processing, providing automatic queueing.
- **Scatter-gather** patterns are fundamental in distributed systems for fanning out a request (like searching multiple databases) and aggregating the fastest or majority responses while bounding tail latencies via a strict timeout.

## 📊 Impact
Extremely positive impact on the overall framework functionality. All code passes data race detection and test suites with comprehensive coverage over edge cases (such as draining channels to prevent panic, gracefully shutting down contexts, and accurately computing token refills).

## 🔬 Measurement
All new nodes have 100% focused unit tests running within milliseconds. Tested extensively using the `-race` flag to ensure safe concurrent operations.

---
*PR created automatically by Jules for task [10417269657611735388](https://jules.google.com/task/10417269657611735388) started by @lhemerly*