### PR TITLE
docs: fix CONTRIBUTING and LICENSE file references in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
I have reviewed the `readme.md` against the current codebase state.

- I updated the `readme.md` to point to the correct files `CONTRIBUTE.md` and `LICENSE.md`, as the original document referred to `CONTRIBUTING.md` and `LICENSE`.
- Regarding missing functionality: I have thoroughly searched the codebase (nodes, middlewares, connections, and events) and verified that **every** feature and component mentioned in the `readme.md` is currently present and implemented in the codebase. There is no missing functionality.

---
*PR created automatically by Jules for task [12872805244122969863](https://jules.google.com/task/12872805244122969863) started by @lhemerly*