### PR TITLE
✨ Add RateLimiterMiddleware and ScatterGatherNode

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +58,47 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimiterMiddleware limits the rate of requests using a token bucket algorithm.
+// refillRate is the number of tokens added per second, and capacity is the maximum
+// burst capacity.
+func RateLimiterMiddleware(refillRate float64, capacity int) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64 = float64(capacity)
+		lastRefill         = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+
+			now := time.Now()
+			elapsed := now.Sub(lastRefill).Seconds()
+
+			// Refill tokens
+			tokensToAdd := elapsed * refillRate
+			if tokensToAdd > 0 {
+				tokens += tokensToAdd
+				if tokens > float64(capacity) {
+					tokens = float64(capacity)
+				}
+
+				lastRefill = now
+			}
+
+			if tokens < 1 {
+				mu.Unlock()
+				return nil, ErrRateLimitExceeded
+			}
+
+			tokens -= 1
+			mu.Unlock()
+
+			return next(input)
 		}
 	}
 }

--- a/node/scatter_gather_node.go
+++ b/node/scatter_gather_node.go
@@ -1,0 +1,138 @@
+package node
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// ScatterGatherNode implements the scatter-gather pattern. It fans out an
+// incoming request to multiple destination nodes concurrently, waits for their
+// responses (up to a configurable timeout), and then gathers all successful outputs
+// into a single aggregated response.
+type ScatterGatherNode struct {
+	*BaseNode
+	destinationsMutex sync.RWMutex
+	destinations      []Node
+	timeout           time.Duration
+}
+
+// NewScatterGatherNode creates a new ScatterGatherNode.
+func NewScatterGatherNode(id string, timeout time.Duration) *ScatterGatherNode {
+	n := &ScatterGatherNode{
+		BaseNode:     NewBaseNode(id),
+		destinations: make([]Node, 0),
+		timeout:      timeout,
+	}
+
+	n.SetProcessFunc(n.scatterGather)
+	return n
+}
+
+// AddDestination adds a node to the list of destinations for the fan-out.
+func (n *ScatterGatherNode) AddDestination(dest Node) {
+	n.destinationsMutex.Lock()
+	defer n.destinationsMutex.Unlock()
+	n.destinations = append(n.destinations, dest)
+}
+
+// scatterGather fans out the input to all destination nodes and collects the results.
+func (n *ScatterGatherNode) scatterGather(input []byte) ([]byte, error) {
+	// Copy destinations to avoid holding lock during Process calls
+	n.destinationsMutex.RLock()
+	dests := make([]Node, len(n.destinations))
+	copy(dests, n.destinations)
+	n.destinationsMutex.RUnlock()
+
+	if len(dests) == 0 {
+		return nil, nil // No destinations to gather from
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), n.timeout)
+	defer cancel()
+
+	type result struct {
+		output []byte
+		err    error
+	}
+
+	resultsChan := make(chan result, len(dests))
+	var wg sync.WaitGroup
+
+	for _, dest := range dests {
+		wg.Add(1)
+		go func(d Node) {
+			defer wg.Done()
+
+			// Clone input to prevent race conditions if destinations modify it
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			output, err := d.Process(inputCopy)
+			resultsChan <- result{output: output, err: err}
+		}(dest)
+	}
+
+	// Wait for all workers to finish
+	doneChan := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneChan)
+	}()
+
+	var finalOutput []byte
+	var wgWaitDone bool
+	var timeoutOccurred bool
+
+	// Collect results until either all finish or timeout occurs
+	select {
+	case <-doneChan:
+		wgWaitDone = true
+	case <-ctx.Done():
+		timeoutOccurred = true
+	}
+
+	var errorsList []error
+
+	// Drain the results channel non-blockingly since workers might still write to it
+	// if we hit the timeout branch. If we hit the doneChan branch, the channel
+	// has exactly len(dests) elements and will be drained safely.
+	if wgWaitDone {
+		close(resultsChan)
+		for res := range resultsChan {
+			if res.err == nil {
+				finalOutput = append(finalOutput, res.output...)
+			} else {
+				errorsList = append(errorsList, res.err)
+			}
+		}
+	} else {
+		// Timeout scenario: drain what we have using a non-blocking select
+		// Avoid closing the channel because pending workers might still try to send.
+		for {
+			select {
+			case res := <-resultsChan:
+				if res.err == nil {
+					finalOutput = append(finalOutput, res.output...)
+				} else {
+					errorsList = append(errorsList, res.err)
+				}
+			default:
+				goto DRAIN_DONE
+			}
+		}
+	DRAIN_DONE:
+	}
+
+	// If no success and we hit a timeout, return timeout
+	if timeoutOccurred && len(finalOutput) == 0 && len(errorsList) == 0 {
+		return nil, ErrProcessTimeout
+	}
+
+	// If everything failed, returning first error for simplicity
+	if len(finalOutput) == 0 && len(errorsList) == len(dests) {
+		return nil, errorsList[0]
+	}
+
+	return finalOutput, nil
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -314,3 +314,57 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
 	}
 }
+
+func TestMiddlewares_RateLimiter(t *testing.T) {
+	n := node.NewBaseNode("ratelimit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// Refill 10 tokens per second, max capacity 2
+	n.Use(node.RateLimiterMiddleware(10.0, 2))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	// 1. Initial requests (capacity is 2, so 2 should succeed)
+	res, err := n.Process([]byte("req1"))
+	if err != nil {
+		t.Fatalf("expected nil error for req1, got %v", err)
+	}
+	if string(res) != "success" {
+		t.Errorf("expected success, got %s", string(res))
+	}
+
+	res, err = n.Process([]byte("req2"))
+	if err != nil {
+		t.Fatalf("expected nil error for req2, got %v", err)
+	}
+	if string(res) != "success" {
+		t.Errorf("expected success, got %s", string(res))
+	}
+
+	// 2. Third request should fail immediately (bucket empty)
+	_, err = n.Process([]byte("req3"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// 3. Wait for 1 token to refill (1 token / 10 tokens/sec = 100ms)
+	// We wait slightly longer to be safe.
+	time.Sleep(120 * time.Millisecond)
+
+	// 4. Request should now succeed
+	res, err = n.Process([]byte("req4"))
+	if err != nil {
+		t.Fatalf("expected nil error after waiting, got %v", err)
+	}
+	if string(res) != "success" {
+		t.Errorf("expected success, got %s", string(res))
+	}
+
+	// 5. Subsequent request should fail again
+	_, err = n.Process([]byte("req5"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+}

--- a/node/tests/scatter_gather_node_test.go
+++ b/node/tests/scatter_gather_node_test.go
@@ -1,0 +1,141 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestScatterGatherNode_Success(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg-node", 500*time.Millisecond)
+	sg.Create()
+	defer sg.Delete()
+
+	dest1 := node.NewBaseNode("dest1")
+	dest1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+	dest1.Create()
+	defer dest1.Delete()
+
+	dest2 := node.NewBaseNode("dest2")
+	dest2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+	dest2.Create()
+	defer dest2.Delete()
+
+	sg.AddDestination(dest1)
+	sg.AddDestination(dest2)
+
+	res, err := sg.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resStr := string(res)
+	if !strings.Contains(resStr, "A") || !strings.Contains(resStr, "B") {
+		t.Errorf("expected output to contain both 'A' and 'B', got %s", resStr)
+	}
+	if len(resStr) != 2 {
+		t.Errorf("expected length 2, got %d", len(resStr))
+	}
+}
+
+func TestScatterGatherNode_PartialFailure(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg-node", 500*time.Millisecond)
+	sg.Create()
+	defer sg.Delete()
+
+	dest1 := node.NewBaseNode("dest1")
+	dest1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+	dest1.Create()
+	defer dest1.Delete()
+
+	dest2 := node.NewBaseNode("dest2")
+	dest2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("some error")
+	})
+	dest2.Create()
+	defer dest2.Delete()
+
+	sg.AddDestination(dest1)
+	sg.AddDestination(dest2)
+
+	res, err := sg.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if string(res) != "A" {
+		t.Errorf("expected output 'A', got %s", string(res))
+	}
+}
+
+func TestScatterGatherNode_CompleteFailure(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg-node", 500*time.Millisecond)
+	sg.Create()
+	defer sg.Delete()
+
+	expectedErr := errors.New("some error")
+	dest1 := node.NewBaseNode("dest1")
+	dest1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, expectedErr
+	})
+	dest1.Create()
+	defer dest1.Delete()
+
+	sg.AddDestination(dest1)
+
+	_, err := sg.Process([]byte("input"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if err.Error() != expectedErr.Error() {
+		t.Fatalf("expected expectedErr, got %v", err)
+	}
+}
+
+func TestScatterGatherNode_Timeout(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg-node", 100*time.Millisecond)
+	sg.Create()
+	defer sg.Delete()
+
+	blockCh := make(chan struct{})
+
+	dest1 := node.NewBaseNode("dest1")
+	dest1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		<-blockCh // block until unblocked or timeout
+		return []byte("slow"), nil
+	})
+	dest1.Create()
+	defer func() {
+		close(blockCh) // unblock to allow Delete() to finish
+		dest1.Delete()
+	}()
+
+	sg.AddDestination(dest1)
+
+	_, err := sg.Process([]byte("input"))
+	if !errors.Is(err, node.ErrProcessTimeout) {
+		t.Fatalf("expected ErrProcessTimeout, got %v", err)
+	}
+}
+
+func TestScatterGatherNode_EmptyDestinations(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg-node", 500*time.Millisecond)
+	sg.Create()
+	defer sg.Delete()
+
+	res, err := sg.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res) != 0 {
+		t.Errorf("expected empty output, got %s", string(res))
+	}
+}

--- a/node/tests/scatter_gather_node_test.go.patch
+++ b/node/tests/scatter_gather_node_test.go.patch
@@ -1,0 +1,89 @@
+<<<<<<< SEARCH
+func TestScatterGatherNode_PartialFailure(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg-node", 500*time.Millisecond)
+	sg.Create()
+	defer sg.Delete()
+
+	dest1 := node.NewBaseNode("dest1")
+	dest1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+	dest1.Create()
+	defer dest1.Delete()
+
+	dest2 := node.NewBaseNode("dest2")
+	dest2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("some error")
+	})
+	dest2.Create()
+	defer dest2.Delete()
+
+	sg.AddDestination(dest1)
+	sg.AddDestination(dest2)
+
+	res, err := sg.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if string(res) != "A" {
+		t.Errorf("expected output 'A', got %s", string(res))
+	}
+}
+=======
+func TestScatterGatherNode_PartialFailure(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg-node", 500*time.Millisecond)
+	sg.Create()
+	defer sg.Delete()
+
+	dest1 := node.NewBaseNode("dest1")
+	dest1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+	dest1.Create()
+	defer dest1.Delete()
+
+	dest2 := node.NewBaseNode("dest2")
+	dest2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("some error")
+	})
+	dest2.Create()
+	defer dest2.Delete()
+
+	sg.AddDestination(dest1)
+	sg.AddDestination(dest2)
+
+	res, err := sg.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if string(res) != "A" {
+		t.Errorf("expected output 'A', got %s", string(res))
+	}
+}
+
+func TestScatterGatherNode_CompleteFailure(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg-node", 500*time.Millisecond)
+	sg.Create()
+	defer sg.Delete()
+
+	expectedErr := errors.New("some error")
+	dest1 := node.NewBaseNode("dest1")
+	dest1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, expectedErr
+	})
+	dest1.Create()
+	defer dest1.Delete()
+
+	sg.AddDestination(dest1)
+
+	_, err := sg.Process([]byte("input"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected expectedErr, got %v", err)
+	}
+}
+>>>>>>> REPLACE


### PR DESCRIPTION
1. **RateLimiterMiddleware**: Adds a token bucket based rate limiter middleware to the `node` package, allowing nodes to protect themselves against traffic bursts. Emits `ErrRateLimitExceeded`.
2. **ScatterGatherNode**: Adds a new structural node pattern to fan out incoming requests to multiple destinations concurrently. It gathers successful responses up to a specific timeout, effectively handling partial failures while preventing complete blocks.
3. Tests have been written for both the middleware and the scatter gather node validating successful flows, timeouts, and error scenarios.

---
*PR created automatically by Jules for task [17865104901844146686](https://jules.google.com/task/17865104901844146686) started by @lhemerly*