### PR TITLE
docs: fix contributing guidelines reference in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,7 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 


### PR DESCRIPTION
Corrected a minor typo in the readme file. 
The instructions in the readme pointed to `CONTRIBUTING.md`, but the file is named `CONTRIBUTE.md`.
Also completed a full review of the code to ensure the `readme.md` functionality perfectly matches the underlying codebase as requested by the user. There is no missing functionality.

---
*PR created automatically by Jules for task [1472362909515385964](https://jules.google.com/task/1472362909515385964) started by @lhemerly*