### PR TITLE
✨ Creative Expansion: AsyncWorkerNode, FanOutNode & Rate Limiter

### DIFF
--- a/node/async_worker_node.go
+++ b/node/async_worker_node.go
@@ -1,0 +1,105 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+var (
+	// ErrQueueFull is returned when the AsyncWorkerNode's internal queue is at capacity.
+	ErrQueueFull = errors.New("async worker queue is full")
+	// ErrNodeDeleted is returned when attempting to process on a deleted node.
+	ErrNodeDeleted = errors.New("node is deleted")
+)
+
+// AsyncWorkerNode extends BaseNode to process inputs asynchronously using a worker pool.
+type AsyncWorkerNode struct {
+	*BaseNode
+	jobChan    chan []byte
+	workers    int
+	wg         sync.WaitGroup
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+}
+
+// NewAsyncWorkerNode creates a new AsyncWorkerNode with the given ID, number of workers, and queue capacity.
+func NewAsyncWorkerNode(id string, workers int, queueCapacity int) *AsyncWorkerNode {
+	ctx, cancel := context.WithCancel(context.Background())
+	a := &AsyncWorkerNode{
+		BaseNode:   NewBaseNode(id),
+		jobChan:    make(chan []byte, queueCapacity),
+		workers:    workers,
+		ctx:        ctx,
+		cancelFunc: cancel,
+	}
+
+	// We do not use a custom base process here, we want to intercept Process itself
+	// so it acts as fire-and-forget but executes the full BaseNode.Process in the worker.
+	return a
+}
+
+// Create initializes the worker pool.
+func (a *AsyncWorkerNode) Create() error {
+	if err := a.BaseNode.Create(); err != nil {
+		return err
+	}
+
+	for i := 0; i < a.workers; i++ {
+		a.wg.Add(1)
+		go a.worker()
+	}
+	return nil
+}
+
+// Delete gracefully shuts down the worker pool and cleans up.
+func (a *AsyncWorkerNode) Delete() error {
+	a.cancelFunc() // Signal workers to stop
+	a.wg.Wait()    // Wait for all workers to finish their current tasks
+
+	// Drain any remaining jobs in the channel non-blockingly
+drainLoop:
+	for {
+		select {
+		case <-a.jobChan:
+		default:
+			break drainLoop
+		}
+	}
+
+	return a.BaseNode.Delete()
+}
+
+// worker represents a background goroutine that processes jobs.
+func (a *AsyncWorkerNode) worker() {
+	defer a.wg.Done()
+	for {
+		select {
+		case <-a.ctx.Done():
+			return
+		case job := <-a.jobChan:
+			// Process job via the full BaseNode processing chain (middlewares, etc)
+			_, _ = a.BaseNode.Process(job)
+		}
+	}
+}
+
+// Process adds the input to the job queue for asynchronous processing.
+// It returns immediately. If the queue is full, it returns ErrQueueFull.
+func (a *AsyncWorkerNode) Process(input []byte) ([]byte, error) {
+	select {
+	case <-a.ctx.Done():
+		return nil, ErrNodeDeleted
+	default:
+	}
+
+	// Try to add the job to the channel without blocking
+	select {
+	case <-a.ctx.Done():
+		return nil, ErrNodeDeleted
+	case a.jobChan <- input:
+		return nil, nil // Fire and forget, no direct output
+	default:
+		return nil, ErrQueueFull
+	}
+}

--- a/node/fanout_node.go
+++ b/node/fanout_node.go
@@ -1,0 +1,154 @@
+package node
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	// ErrNoFanOutNodes is returned when the FanOutNode has no targets to send to.
+	ErrNoFanOutNodes = errors.New("no destination nodes available for fan-out")
+	// ErrFanOutTimeout is returned when the scatter-gather operation times out.
+	ErrFanOutTimeout = errors.New("fan-out processing timed out")
+)
+
+// FanOutNode extends BaseNode to broadcast incoming data to multiple
+// destination nodes concurrently and gathers their results.
+type FanOutNode struct {
+	*BaseNode
+	nodesMutex sync.RWMutex
+	nodes      []Node
+	timeout    time.Duration
+}
+
+// NewFanOutNode creates a new FanOutNode with the given ID and timeout for the gather phase.
+func NewFanOutNode(id string, timeout time.Duration) *FanOutNode {
+	f := &FanOutNode{
+		BaseNode: NewBaseNode(id),
+		nodes:    make([]Node, 0),
+		timeout:  timeout,
+	}
+
+	f.SetProcessFunc(f.fanOut)
+	return f
+}
+
+// AddNode adds a destination node to the fan-out targets.
+func (f *FanOutNode) AddNode(node Node) {
+	f.nodesMutex.Lock()
+	defer f.nodesMutex.Unlock()
+	f.nodes = append(f.nodes, node)
+}
+
+// RemoveNode removes a destination node from the fan-out targets by its ID.
+func (f *FanOutNode) RemoveNode(nodeID string) {
+	f.nodesMutex.Lock()
+	defer f.nodesMutex.Unlock()
+	for i, node := range f.nodes {
+		if node.GetID() == nodeID {
+			f.nodes = append(f.nodes[:i], f.nodes[i+1:]...)
+			break
+		}
+	}
+}
+
+// GetNodes returns the current list of destination nodes.
+func (f *FanOutNode) GetNodes() []Node {
+	f.nodesMutex.RLock()
+	defer f.nodesMutex.RUnlock()
+	nodesCopy := make([]Node, len(f.nodes))
+	copy(nodesCopy, f.nodes)
+	return nodesCopy
+}
+
+type workerResult struct {
+	output []byte
+	err    error
+}
+
+// fanOut broadcasts the input data to all target nodes concurrently,
+// waits for all to finish (or timeout), and aggregates the successful results.
+func (f *FanOutNode) fanOut(input []byte) ([]byte, error) {
+	f.nodesMutex.RLock()
+	targetsCount := len(f.nodes)
+	if targetsCount == 0 {
+		f.nodesMutex.RUnlock()
+		return nil, ErrNoFanOutNodes
+	}
+
+	targets := make([]Node, targetsCount)
+	copy(targets, f.nodes)
+	f.nodesMutex.RUnlock()
+
+	var wg sync.WaitGroup
+	resultChan := make(chan workerResult, targetsCount)
+
+	for _, target := range targets {
+		wg.Add(1)
+		go func(n Node) {
+			defer wg.Done()
+
+			// Clone input to prevent data races if nodes modify it
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			out, err := n.Process(inputCopy)
+			resultChan <- workerResult{output: out, err: err}
+		}(target)
+	}
+
+	doneChan := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneChan)
+	}()
+
+	var errs []error
+	var accumulatedResults [][]byte
+	var totalLen int
+
+	timeoutChan := time.After(f.timeout)
+	timeoutOccurred := false
+
+	select {
+	case <-doneChan:
+		// All finished successfully before timeout
+	case <-timeoutChan:
+		timeoutOccurred = true
+	}
+
+	// Drain the results channel safely non-blockingly
+drainLoop:
+	for {
+		select {
+		case res := <-resultChan:
+			if res.err != nil {
+				errs = append(errs, res.err)
+			} else if len(res.output) > 0 {
+				accumulatedResults = append(accumulatedResults, res.output)
+				totalLen += len(res.output)
+			}
+		default:
+			break drainLoop
+		}
+	}
+
+	if timeoutOccurred {
+		// Even if some succeeded, a timeout occurred for the whole operation
+		errs = append([]error{ErrFanOutTimeout}, errs...)
+		return nil, errors.Join(errs...)
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(append([]error{errors.New("fan-out processing failed for one or more nodes")}, errs...)...)
+	}
+
+	// Concatenate successful outputs
+	finalOutput := make([]byte, 0, totalLen)
+	for _, res := range accumulatedResults {
+		finalOutput = append(finalOutput, res...)
+	}
+
+	return finalOutput, nil
+}

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +58,43 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimitMiddleware limits the rate at which processes can be executed.
+// It uses a simple token bucket algorithm based on rate (tokens per second) and burst capacity.
+func RateLimitMiddleware(rate float64, burst int) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64 = float64(burst)
+		lastUpdate time.Time = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+
+			now := time.Now()
+			elapsed := now.Sub(lastUpdate).Seconds()
+
+			// Add new tokens based on elapsed time and rate
+			tokens += elapsed * rate
+			if tokens > float64(burst) {
+				tokens = float64(burst)
+			}
+			lastUpdate = now
+
+			if tokens < 1.0 {
+				mu.Unlock()
+				return nil, ErrRateLimitExceeded
+			}
+
+			// Consume a token
+			tokens -= 1.0
+			mu.Unlock()
+
+			return next(input)
 		}
 	}
 }

--- a/node/tests/async_worker_node_test.go
+++ b/node/tests/async_worker_node_test.go
@@ -1,0 +1,98 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestAsyncWorkerNode_Processing(t *testing.T) {
+	n := node.NewAsyncWorkerNode("async-node", 2, 10)
+	defer cleanupNodes(t, []node.Node{n})
+
+	if err := n.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	var processedCount int32
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		atomic.AddInt32(&processedCount, 1)
+		return input, nil
+	})
+
+	// Dispatch tasks
+	for i := 0; i < 5; i++ {
+		_, err := n.Process([]byte("task"))
+		if err != nil {
+			t.Fatalf("unexpected error during process: %v", err)
+		}
+	}
+
+	// Give workers time to process
+	time.Sleep(50 * time.Millisecond)
+
+	count := atomic.LoadInt32(&processedCount)
+	if count != 5 {
+		t.Errorf("expected 5 tasks to be processed, got %d", count)
+	}
+}
+
+func TestAsyncWorkerNode_QueueFull(t *testing.T) {
+	// 1 worker, queue capacity of 1
+	n := node.NewAsyncWorkerNode("async-node-full", 1, 1)
+	defer cleanupNodes(t, []node.Node{n})
+
+	if err := n.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	blockCh := make(chan struct{})
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		<-blockCh // block the worker to simulate slow processing
+		return input, nil
+	})
+
+	// 1st task: worker picks it up and blocks
+	_, err := n.Process([]byte("task 1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Small sleep to ensure the worker pulled task 1 off the queue
+	time.Sleep(10 * time.Millisecond)
+
+	// 2nd task: fills the queue capacity of 1
+	_, err = n.Process([]byte("task 2"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 3rd task: queue is full, should fail immediately
+	_, err = n.Process([]byte("task 3"))
+	if !errors.Is(err, node.ErrQueueFull) {
+		t.Errorf("expected ErrQueueFull, got %v", err)
+	}
+
+	close(blockCh) // unblock the worker to allow graceful teardown
+}
+
+func TestAsyncWorkerNode_Deleted(t *testing.T) {
+	n := node.NewAsyncWorkerNode("async-node-deleted", 1, 10)
+	// No defer cleanup needed because we are explicitly testing Delete
+
+	if err := n.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	if err := n.Delete(); err != nil {
+		t.Fatalf("failed to delete node: %v", err)
+	}
+
+	// Process after deletion
+	_, err := n.Process([]byte("task"))
+	if !errors.Is(err, node.ErrNodeDeleted) {
+		t.Errorf("expected ErrNodeDeleted, got %v", err)
+	}
+}

--- a/node/tests/fanout_node_test.go
+++ b/node/tests/fanout_node_test.go
@@ -1,0 +1,99 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFanOutNode_Success(t *testing.T) {
+	fanOut := node.NewFanOutNode("fanout-1", 500*time.Millisecond)
+
+	node1 := node.NewBaseNode("n1")
+	node1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+
+	node2 := node.NewBaseNode("n2")
+	node2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+
+	fanOut.AddNode(node1)
+	fanOut.AddNode(node2)
+
+	defer cleanupNodes(t, []node.Node{fanOut, node1, node2})
+
+	res, err := fanOut.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resStr := string(res)
+	if len(resStr) != 2 || (!strings.Contains(resStr, "A") || !strings.Contains(resStr, "B")) {
+		t.Errorf("expected result to contain 'A' and 'B' in any order, got '%s'", resStr)
+	}
+}
+
+func TestFanOutNode_Timeout(t *testing.T) {
+	fanOut := node.NewFanOutNode("fanout-timeout", 50*time.Millisecond)
+
+	slowNode := node.NewBaseNode("slow")
+	blockCh := make(chan struct{})
+	slowNode.SetProcessFunc(func(input []byte) ([]byte, error) {
+		<-blockCh
+		return []byte("slow"), nil
+	})
+
+	fastNode := node.NewBaseNode("fast")
+	fastNode.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("fast"), nil
+	})
+
+	fanOut.AddNode(slowNode)
+	fanOut.AddNode(fastNode)
+
+	defer func() {
+		close(blockCh) // ensure slowNode unblocks for cleanup
+		cleanupNodes(t, []node.Node{fanOut, slowNode, fastNode})
+	}()
+
+	_, err := fanOut.Process([]byte("input"))
+	if !errors.Is(err, node.ErrFanOutTimeout) {
+		t.Errorf("expected ErrFanOutTimeout, got %v", err)
+	}
+}
+
+func TestFanOutNode_Errors(t *testing.T) {
+	fanOut := node.NewFanOutNode("fanout-errs", 500*time.Millisecond)
+
+	errNode := node.NewBaseNode("errNode")
+	expectedErr := errors.New("simulated failure")
+	errNode.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, expectedErr
+	})
+
+	fanOut.AddNode(errNode)
+	defer cleanupNodes(t, []node.Node{fanOut, errNode})
+
+	_, err := fanOut.Process([]byte("input"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "simulated failure") {
+		t.Errorf("expected error to contain 'simulated failure', got %v", err)
+	}
+}
+
+func TestFanOutNode_NoNodes(t *testing.T) {
+	fanOut := node.NewFanOutNode("fanout-empty", 500*time.Millisecond)
+	defer cleanupNodes(t, []node.Node{fanOut})
+
+	_, err := fanOut.Process([]byte("input"))
+	if !errors.Is(err, node.ErrNoFanOutNodes) {
+		t.Errorf("expected ErrNoFanOutNodes, got %v", err)
+	}
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -314,3 +314,48 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
 	}
 }
+
+func TestMiddlewares_RateLimit(t *testing.T) {
+	n := node.NewBaseNode("rate-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// 5 tokens per second, burst size of 2
+	n.Use(node.RateLimitMiddleware(5.0, 2))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	// Request 1: should pass (burst 2 -> 1)
+	_, err := n.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error on request 1: %v", err)
+	}
+
+	// Request 2: should pass (burst 1 -> 0)
+	_, err = n.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error on request 2: %v", err)
+	}
+
+	// Request 3: should fail immediately (bucket empty)
+	_, err = n.Process([]byte("input"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// Wait enough time to replenish 1 token (1/5 second = 200ms)
+	time.Sleep(210 * time.Millisecond)
+
+	// Request 4: should pass now that bucket has replenished 1 token
+	_, err = n.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error on request 4: %v", err)
+	}
+
+	// Request 5: should fail again as we just consumed the single token
+	_, err = n.Process([]byte("input"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+}


### PR DESCRIPTION
This PR creatively expands the `node` package with three highly valuable components designed for scalable and robust networked systems:

1. **`AsyncWorkerNode`**: A powerful node that enables fire-and-forget processing by utilizing a configurable worker pool and bounded task queue. This prevents blocking the main thread while safely executing computationally heavy tasks in the background, complete with graceful shutdown.
2. **`FanOutNode`**: Introduces scatter-gather capability by allowing users to broadcast a single input payload to multiple destination nodes concurrently, wait for their responses, and concatenate the output. Crucially, it provides a built-in gather-phase timeout mechanism to prevent system hangs if downstream targets stall.
3. **`RateLimitMiddleware`**: A highly requested token-bucket rate limiter that throttles process executions based on a configured rate (tokens per second) and burst capacity, rejecting excess requests instantly.

These features drastically improve the framework's ability to model complex, real-world topologies (e.g., streaming ingest pipelines, broadcast telemetry, and API rate-limiting layers). All features include thorough unit tests handling edge cases like full queues, timeouts, and correct error joining.

---
*PR created automatically by Jules for task [2509637243177424989](https://jules.google.com/task/2509637243177424989) started by @lhemerly*