### PR TITLE
Sync readme.md with correct file names

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
Updated the file references in `readme.md` to point to the correct files `CONTRIBUTE.md` and `LICENSE.md`. I also verified that the codebase is aligned with the capabilities mentioned in the readme, except for a missing feature "ScatterGatherNode" which is not implemented yet but was missing from the documentation (which I didn't find mention in `readme.md`). The readme is accurate about the advanced node types `FailoverNode`, `LoadBalancerNode`, `PipelineNode`, `RouterNode`, and `MapReduceNode`. Same for middlewares. 

---
*PR created automatically by Jules for task [11350143174724097476](https://jules.google.com/task/11350143174724097476) started by @lhemerly*