### PR TITLE
feat(node): add ScatterGatherNode and new middlewares

### DIFF
--- a/node/map_reduce_node.go
+++ b/node/map_reduce_node.go
@@ -75,7 +75,11 @@ func (mr *MapReduceNode) mapReduceProcess(input []byte) ([]byte, error) {
 
 	// Flatten results into a single byte slice for the reducer
 	// Format: simple concatenation for this basic implementation.
-	var reducedInput []byte
+	var totalLen int
+	for _, res := range results {
+		totalLen += len(res)
+	}
+	reducedInput := make([]byte, 0, totalLen)
 	for _, res := range results {
 		reducedInput = append(reducedInput, res...)
 	}

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -2,10 +2,10 @@ package node
 
 import (
 	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -61,6 +61,68 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 	}
 }
 
+// RateLimiterMiddleware limits the number of requests processed per second using a token bucket.
+func RateLimiterMiddleware(rate int, burst int) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64 = float64(burst)
+		lastUpdate         = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+			now := time.Now()
+			elapsed := now.Sub(lastUpdate).Seconds()
+			tokens += elapsed * float64(rate)
+			if tokens > float64(burst) {
+				tokens = float64(burst)
+			}
+			lastUpdate = now
+
+			if tokens >= 1 {
+				tokens--
+				mu.Unlock()
+				return next(input)
+			}
+			mu.Unlock()
+
+			return nil, errors.New("rate limit exceeded")
+		}
+	}
+}
+
+// MetricsTracker stores execution metrics for the MetricsMiddleware.
+type MetricsTracker struct {
+	TotalRequests uint64
+	Successes     uint64
+	Failures      uint64
+	TotalDuration int64 // in nanoseconds
+}
+
+// MetricsMiddleware tracks processing metrics such as requests, successes, failures, and latency.
+func MetricsMiddleware(tracker *MetricsTracker) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			atomic.AddUint64(&tracker.TotalRequests, 1)
+			start := time.Now()
+
+			output, err := next(input)
+
+			duration := time.Since(start).Nanoseconds()
+			atomic.AddInt64(&tracker.TotalDuration, duration)
+
+			if err != nil {
+				atomic.AddUint64(&tracker.Failures, 1)
+			} else {
+				atomic.AddUint64(&tracker.Successes, 1)
+			}
+
+			return output, err
+		}
+	}
+}
+
 // CacheMiddleware caches the output of successful processes for a given TTL, keyed by the hash of the input.
 func CacheMiddleware(ttl time.Duration) Middleware {
 	type cacheEntry struct {
@@ -70,14 +132,12 @@ func CacheMiddleware(ttl time.Duration) Middleware {
 
 	var (
 		mu    sync.RWMutex
-		cache = make(map[string]cacheEntry)
+		cache = make(map[[32]byte]cacheEntry)
 	)
 
 	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
 		return func(input []byte) ([]byte, error) {
-			hasher := sha256.New()
-			hasher.Write(input)
-			key := hex.EncodeToString(hasher.Sum(nil))
+			key := sha256.Sum256(input)
 
 			mu.RLock()
 			entry, exists := cache[key]

--- a/node/scatter_gather_node.go
+++ b/node/scatter_gather_node.go
@@ -1,0 +1,154 @@
+package node
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// ScatterGatherNode represents a node that broadcasts an input to multiple targets
+// concurrently and aggregates the successful results. It supports a timeout for the overall process.
+type ScatterGatherNode struct {
+	*BaseNode
+	targets []Node
+	timeout time.Duration
+}
+
+// NewScatterGatherNode creates a new ScatterGatherNode.
+func NewScatterGatherNode(id string, targets []Node, timeout time.Duration) *ScatterGatherNode {
+	if len(targets) == 0 {
+		panic("ScatterGatherNode requires at least one target")
+	}
+
+	sgNode := &ScatterGatherNode{
+		BaseNode: NewBaseNode(id),
+		targets:  targets,
+		timeout:  timeout,
+	}
+
+	sgNode.SetProcessFunc(sgNode.scatterGatherProcess)
+
+	return sgNode
+}
+
+// scatterGatherProcess handles the scatter-gather lifecycle.
+func (sg *ScatterGatherNode) scatterGatherProcess(input []byte) ([]byte, error) {
+	var wg sync.WaitGroup
+	resultChan := make(chan []byte, len(sg.targets))
+	errChan := make(chan error, len(sg.targets))
+
+	// Scatter
+	for _, target := range sg.targets {
+		wg.Add(1)
+		go func(t Node) {
+			defer wg.Done()
+
+			// Clone input to prevent data races
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			res, err := t.Process(inputCopy)
+			if err != nil {
+				errChan <- err
+			} else {
+				resultChan <- res
+			}
+		}(target)
+	}
+
+	// Done channel to wait for all workers
+	doneChan := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneChan)
+	}()
+
+	var timeoutOccurred bool
+	var timeoutChan <-chan time.Time
+	if sg.timeout > 0 {
+		timeoutChan = time.After(sg.timeout)
+	}
+
+	select {
+	case <-doneChan:
+		// All targets finished
+	case <-timeoutChan:
+		timeoutOccurred = true
+	}
+
+	// Gather
+	// Close result and err channels if we waited for doneChan.
+	// If timeout occurred, some workers might still be running and trying to write to the channels,
+	// so we don't close them to avoid "send on closed channel" panic. We let GC handle them.
+
+	// Collect results using a non-blocking loop
+	var results [][]byte
+	var errs []error
+
+	// Helper to drain channels
+	drainChannels := func() {
+		for {
+			select {
+			case res := <-resultChan:
+				results = append(results, res)
+			case err := <-errChan:
+				errs = append(errs, err)
+			default:
+				return // Channels drained
+			}
+		}
+	}
+	drainChannels()
+
+	if timeoutOccurred {
+		return nil, ErrProcessTimeout
+	}
+
+	// If all targets failed and there was no timeout, return an error
+	if len(results) == 0 && len(errs) == len(sg.targets) {
+		return nil, errors.Join(append([]error{errors.New("all targets failed in scatter-gather")}, errs...)...)
+	}
+
+	// Flatten results
+	var totalLen int
+	for _, res := range results {
+		totalLen += len(res)
+	}
+	flattened := make([]byte, 0, totalLen)
+	for _, res := range results {
+		flattened = append(flattened, res...)
+	}
+
+	return flattened, nil
+}
+
+// Create initializes the scatter-gather node and its dependencies.
+func (sg *ScatterGatherNode) Create() error {
+	if err := sg.BaseNode.Create(); err != nil {
+		return err
+	}
+	for _, t := range sg.targets {
+		if err := t.Create(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Delete cleans up the scatter-gather node and its dependencies.
+func (sg *ScatterGatherNode) Delete() error {
+	var errs []error
+	if err := sg.BaseNode.Delete(); err != nil {
+		errs = append(errs, err)
+	}
+	for _, t := range sg.targets {
+		if err := t.Delete(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -314,3 +314,91 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
 	}
 }
+
+func TestMiddlewares_RateLimiter(t *testing.T) {
+	n := node.NewBaseNode("rate-limiter-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// Rate limit: 2 requests per second, burst: 2
+	n.Use(node.RateLimiterMiddleware(2, 2))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	// Burst capacity: first 2 requests should succeed immediately
+	for i := 0; i < 2; i++ {
+		_, err := n.Process([]byte("input"))
+		if err != nil {
+			t.Fatalf("expected success on burst %d, got %v", i+1, err)
+		}
+	}
+
+	// Next request should fail because bucket is empty
+	_, err := n.Process([]byte("input"))
+	if err == nil || err.Error() != "rate limit exceeded" {
+		t.Fatalf("expected 'rate limit exceeded' error, got %v", err)
+	}
+
+	// Wait 600ms (more than 500ms required for 1 token at 2 rps)
+	time.Sleep(600 * time.Millisecond)
+
+	// Now 1 token should be available
+	_, err = n.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("expected success after waiting, got %v", err)
+	}
+
+	// And the next immediately fails again
+	_, err = n.Process([]byte("input"))
+	if err == nil || err.Error() != "rate limit exceeded" {
+		t.Fatalf("expected 'rate limit exceeded' error, got %v", err)
+	}
+}
+
+func TestMiddlewares_Metrics(t *testing.T) {
+	n := node.NewBaseNode("metrics-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	tracker := &node.MetricsTracker{}
+	n.Use(node.MetricsMiddleware(tracker))
+
+	var fail bool
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(10 * time.Millisecond)
+		if fail {
+			return nil, errors.New("simulated error")
+		}
+		return []byte("success"), nil
+	})
+
+	// Process success
+	n.Process([]byte("input1"))
+
+	if tracker.TotalRequests != 1 {
+		t.Errorf("expected 1 total request, got %d", tracker.TotalRequests)
+	}
+	if tracker.Successes != 1 {
+		t.Errorf("expected 1 success, got %d", tracker.Successes)
+	}
+	if tracker.Failures != 0 {
+		t.Errorf("expected 0 failures, got %d", tracker.Failures)
+	}
+	if tracker.TotalDuration == 0 {
+		t.Errorf("expected TotalDuration > 0, got %d", tracker.TotalDuration)
+	}
+
+	// Process failure
+	fail = true
+	n.Process([]byte("input2"))
+
+	if tracker.TotalRequests != 2 {
+		t.Errorf("expected 2 total requests, got %d", tracker.TotalRequests)
+	}
+	if tracker.Successes != 1 {
+		t.Errorf("expected 1 success, got %d", tracker.Successes)
+	}
+	if tracker.Failures != 1 {
+		t.Errorf("expected 1 failure, got %d", tracker.Failures)
+	}
+}

--- a/node/tests/scatter_gather_node_test.go
+++ b/node/tests/scatter_gather_node_test.go
@@ -1,0 +1,121 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestScatterGatherNode_Success(t *testing.T) {
+	t1 := node.NewBaseNode("target1")
+	t1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("t1:"), input...), nil
+	})
+
+	t2 := node.NewBaseNode("target2")
+	t2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("t2:"), input...), nil
+	})
+
+	sgNode := node.NewScatterGatherNode("sg1", []node.Node{t1, t2}, 0)
+	defer cleanupNodes(t, []node.Node{t1, t2, sgNode})
+
+	if err := sgNode.Create(); err != nil {
+		t.Fatalf("unexpected error during Create: %v", err)
+	}
+
+	res, err := sgNode.Process([]byte("data"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resStr := string(res)
+	if !strings.Contains(resStr, "t1:data") || !strings.Contains(resStr, "t2:data") {
+		t.Errorf("expected result to contain 't1:data' and 't2:data', got '%s'", resStr)
+	}
+}
+
+func TestScatterGatherNode_PartialFailure(t *testing.T) {
+	t1 := node.NewBaseNode("target1")
+	t1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("t1:"), input...), nil
+	})
+
+	t2 := node.NewBaseNode("target2")
+	t2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("simulated error")
+	})
+
+	sgNode := node.NewScatterGatherNode("sg1", []node.Node{t1, t2}, 0)
+	defer cleanupNodes(t, []node.Node{t1, t2, sgNode})
+
+	if err := sgNode.Create(); err != nil {
+		t.Fatalf("unexpected error during Create: %v", err)
+	}
+
+	res, err := sgNode.Process([]byte("data"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resStr := string(res)
+	if resStr != "t1:data" {
+		t.Errorf("expected result to contain only 't1:data', got '%s'", resStr)
+	}
+}
+
+func TestScatterGatherNode_AllFailure(t *testing.T) {
+	t1 := node.NewBaseNode("target1")
+	t1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("simulated error 1")
+	})
+
+	t2 := node.NewBaseNode("target2")
+	t2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("simulated error 2")
+	})
+
+	sgNode := node.NewScatterGatherNode("sg1", []node.Node{t1, t2}, 0)
+	defer cleanupNodes(t, []node.Node{t1, t2, sgNode})
+
+	if err := sgNode.Create(); err != nil {
+		t.Fatalf("unexpected error during Create: %v", err)
+	}
+
+	_, err := sgNode.Process([]byte("data"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "all targets failed") {
+		t.Errorf("expected error to mention 'all targets failed', got '%v'", err)
+	}
+}
+
+func TestScatterGatherNode_Timeout(t *testing.T) {
+	t1 := node.NewBaseNode("target1")
+	t1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("t1:"), input...), nil
+	})
+
+	t2 := node.NewBaseNode("target2")
+	t2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond) // slow target
+		return append([]byte("t2:"), input...), nil
+	})
+
+	// Timeout faster than t2, slower than t1
+	sgNode := node.NewScatterGatherNode("sg1", []node.Node{t1, t2}, 50*time.Millisecond)
+	defer cleanupNodes(t, []node.Node{t1, t2, sgNode})
+
+	if err := sgNode.Create(); err != nil {
+		t.Fatalf("unexpected error during Create: %v", err)
+	}
+
+	_, err := sgNode.Process([]byte("data"))
+	if !errors.Is(err, node.ErrProcessTimeout) {
+		t.Fatalf("expected ErrProcessTimeout, got %v", err)
+	}
+}


### PR DESCRIPTION
💡 What:
Added a new `ScatterGatherNode` for concurrent, timeout-supported target processing.
Added `MetricsMiddleware` and `RateLimiterMiddleware`.
Optimized `MapReduceNode` memory allocation.
Optimized `CacheMiddleware` map keys.

🎯 Why:
Improve performance and introduce versatile networking abstractions in the Node framework.

📊 Impact:
More functional processing nodes.
Improved framework resilience and metrics observability.
Decreased garbage collection overhead.

🔬 Measurement:
Included comprehensive unit tests spanning edge and timeout cases which pass reliably.

---
*PR created automatically by Jules for task [10409806750843474566](https://jules.google.com/task/10409806750843474566) started by @lhemerly*