### PR TITLE
Fix gRPC connection example in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,10 @@ import (
     "context"
     "fmt"
     "log"
+
     "github.com/lhemerly/Constellation/connection"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -155,7 +158,7 @@ func main() {
     ctx := context.Background()
 
     // Create a new gRPC connection
-    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to create connection: %v", err)
     }


### PR DESCRIPTION
- Added `grpc.WithTransportCredentials(insecure.NewCredentials())` to the `NewConnection` call in the `connection` package example.
- Added missing imports for `google.golang.org/grpc` and `google.golang.org/grpc/credentials/insecure`.

Also verified the codebase against the `readme.md` and confirmed that all functionality documented in the readme is correctly implemented in the codebase.

---
*PR created automatically by Jules for task [17511030489543866002](https://jules.google.com/task/17511030489543866002) started by @lhemerly*