### PR TITLE
feat: add RateLimitMiddleware

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -12,6 +12,7 @@ import (
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +58,41 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimitMiddleware restricts the rate of requests to a specified number of tokens per second.
+// It uses a token bucket algorithm to rate limit requests.
+func RateLimitMiddleware(capacity int, refillRate float64) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64   = float64(capacity)
+		lastRefill time.Time = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+
+			now := time.Now()
+			elapsed := now.Sub(lastRefill).Seconds()
+
+			// Refill tokens
+			tokens += elapsed * refillRate
+			if tokens > float64(capacity) {
+				tokens = float64(capacity)
+			}
+			lastRefill = now
+
+			if tokens >= 1.0 {
+				tokens -= 1.0
+				mu.Unlock()
+				return next(input)
+			}
+
+			mu.Unlock()
+			return nil, ErrRateLimitExceeded
 		}
 	}
 }

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -314,3 +314,55 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
 	}
 }
+
+func TestMiddlewares_RateLimit(t *testing.T) {
+	n := node.NewBaseNode("rate-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// Allow 2 requests immediately, refill 10 tokens per second (1 token per 100ms)
+	n.Use(node.RateLimitMiddleware(2, 10.0))
+
+	var executions int
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		executions++
+		return []byte("success"), nil
+	})
+
+	// 1. Initial requests within capacity should succeed
+	for i := 0; i < 2; i++ {
+		res, err := n.Process([]byte("input"))
+		if err != nil {
+			t.Fatalf("expected nil error on request %d, got %v", i, err)
+		}
+		if string(res) != "success" {
+			t.Errorf("expected success, got %s", string(res))
+		}
+	}
+	if executions != 2 {
+		t.Fatalf("expected 2 executions, got %d", executions)
+	}
+
+	// 2. Immediate next request should be rate-limited
+	_, err := n.Process([]byte("input"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+	if executions != 2 {
+		t.Fatalf("expected executions to remain 2, got %d", executions)
+	}
+
+	// 3. Wait for refill (100ms for 1 token)
+	time.Sleep(150 * time.Millisecond)
+
+	// 4. Request should succeed again
+	res, err := n.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("expected nil error after wait, got %v", err)
+	}
+	if string(res) != "success" {
+		t.Errorf("expected success, got %s", string(res))
+	}
+	if executions != 3 {
+		t.Fatalf("expected 3 executions, got %d", executions)
+	}
+}


### PR DESCRIPTION
This PR introduces `RateLimitMiddleware`, implementing a token bucket rate-limiting mechanism for node processing.
- Adds token-based rate limits utilizing a `sync.Mutex` and `time.Now()` to avoid the overhead of background `time.Ticker` goroutines.
- Returns `ErrRateLimitExceeded` when requests surpass capacity.
- Accompanying test case added to verify initial bursts, limits, and subsequent recharges based on the `refillRate`.

---
*PR created automatically by Jules for task [17180751422130327671](https://jules.google.com/task/17180751422130327671) started by @lhemerly*