### PR TITLE
docs: fix gRPC connection usage examples

### DIFF
--- a/connection/connection.go
+++ b/connection/connection.go
@@ -13,7 +13,7 @@
 // Usage:
 //
 //	factory := connection.NewConnectionFactory()
-//	conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+//	conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
 //	if err != nil {
 //	    log.Fatalf("Failed to create connection: %v", err)
 //	}

--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,8 @@ import (
     "fmt"
     "log"
     "github.com/lhemerly/Constellation/connection"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -155,7 +157,7 @@ func main() {
     ctx := context.Background()
 
     // Create a new gRPC connection
-    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to create connection: %v", err)
     }


### PR DESCRIPTION
The `readme.md` connection usage example for creating a gRPC connection was failing when run due to a missing transport security setting. In newer versions of `grpc-go`, clients must explicitly set transport credentials if they want to use an insecure connection. 

This PR updates both the `readme.md` and `connection/connection.go` package documentation to include the `grpc.WithTransportCredentials(insecure.NewCredentials())` dial option and the necessary imports, ensuring the provided code snippets compile and run successfully.

- Adds `grpc.WithTransportCredentials(insecure.NewCredentials())` to `NewConnection` examples.
- Adds `google.golang.org/grpc` and `google.golang.org/grpc/credentials/insecure` to the `readme.md` imports snippet.

---
*PR created automatically by Jules for task [13449714955141653194](https://jules.google.com/task/13449714955141653194) started by @lhemerly*