### PR TITLE
Add Metrics/RateLimiter Middlewares and ScatterGather/WorkerPool Nodes

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -6,13 +6,85 @@ import (
 	"errors"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
+
+// Metrics holds processing statistics for the MetricsMiddleware.
+type Metrics struct {
+	Invocations         uint64
+	Successes           uint64
+	Failures            uint64
+	TotalProcessingTime int64 // Stored in nanoseconds
+}
+
+// MetricsMiddleware records invocations, successes, failures, and processing times.
+func MetricsMiddleware(metrics *Metrics) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			atomic.AddUint64(&metrics.Invocations, 1)
+			start := time.Now()
+
+			output, err := next(input)
+
+			duration := time.Since(start)
+			atomic.AddInt64(&metrics.TotalProcessingTime, duration.Nanoseconds())
+
+			if err != nil {
+				atomic.AddUint64(&metrics.Failures, 1)
+			} else {
+				atomic.AddUint64(&metrics.Successes, 1)
+			}
+
+			return output, err
+		}
+	}
+}
+
+// RateLimiterMiddleware limits the number of requests using a token bucket approach.
+func RateLimiterMiddleware(capacity int, refillRate time.Duration) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     int
+		lastRefill time.Time
+	)
+	tokens = capacity
+	lastRefill = time.Now()
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+
+			now := time.Now()
+			elapsed := now.Sub(lastRefill)
+			refillTokens := int(elapsed / refillRate)
+
+			if refillTokens > 0 {
+				tokens += refillTokens
+				if tokens > capacity {
+					tokens = capacity
+				}
+				lastRefill = now
+			}
+
+			if tokens <= 0 {
+				mu.Unlock()
+				return nil, ErrRateLimitExceeded
+			}
+
+			tokens--
+			mu.Unlock()
+
+			return next(input)
+		}
+	}
+}
 
 // LoggingMiddleware logs the payload size and processing time.
 func LoggingMiddleware(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {

--- a/node/scatter_gather_node.go
+++ b/node/scatter_gather_node.go
@@ -1,0 +1,129 @@
+package node
+
+import (
+	"errors"
+	"sync"
+	"time"
+)
+
+// ScatterGatherNode broadcasts input to multiple target nodes and gathers their responses.
+type ScatterGatherNode struct {
+	*BaseNode
+	targetsMutex sync.RWMutex
+	targets      []Node
+	timeout      time.Duration
+}
+
+// NewScatterGatherNode creates a new ScatterGatherNode with a specific timeout.
+func NewScatterGatherNode(id string, timeout time.Duration) *ScatterGatherNode {
+	sgn := &ScatterGatherNode{
+		BaseNode: NewBaseNode(id),
+		targets:  make([]Node, 0),
+		timeout:  timeout,
+	}
+
+	sgn.SetProcessFunc(sgn.scatterGather)
+	return sgn
+}
+
+// AddTarget adds a destination node.
+func (sgn *ScatterGatherNode) AddTarget(node Node) {
+	sgn.targetsMutex.Lock()
+	defer sgn.targetsMutex.Unlock()
+	sgn.targets = append(sgn.targets, node)
+}
+
+// RemoveTarget removes a target by its ID.
+func (sgn *ScatterGatherNode) RemoveTarget(nodeID string) {
+	sgn.targetsMutex.Lock()
+	defer sgn.targetsMutex.Unlock()
+	for i, target := range sgn.targets {
+		if target.GetID() == nodeID {
+			sgn.targets = append(sgn.targets[:i], sgn.targets[i+1:]...)
+			break
+		}
+	}
+}
+
+// scatterGather processes the input by dispatching it to all targets concurrently.
+func (sgn *ScatterGatherNode) scatterGather(input []byte) ([]byte, error) {
+	sgn.targetsMutex.RLock()
+	targetsCount := len(sgn.targets)
+	targetsCopy := make([]Node, targetsCount)
+	copy(targetsCopy, sgn.targets)
+	sgn.targetsMutex.RUnlock()
+
+	if targetsCount == 0 {
+		return nil, errors.New("no targets configured")
+	}
+
+	var wg sync.WaitGroup
+	// Create buffered channels so slow workers won't block forever if we timeout
+	results := make(chan []byte, targetsCount)
+	errs := make(chan error, targetsCount)
+
+	for _, target := range targetsCopy {
+		wg.Add(1)
+		go func(t Node) {
+			defer wg.Done()
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			res, err := t.Process(inputCopy)
+			if err != nil {
+				errs <- err
+			} else {
+				results <- res
+			}
+		}(target)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	timeoutChan := time.After(sgn.timeout)
+	timeoutOccurred := false
+	select {
+	case <-done:
+		// all finished normally
+	case <-timeoutChan:
+		// timed out
+		timeoutOccurred = true
+	}
+
+	// Drain results and errors
+	var finalResults [][]byte
+	var allErrs []error
+
+drainLoop:
+	for {
+		select {
+		case r := <-results:
+			finalResults = append(finalResults, r)
+		case e := <-errs:
+			allErrs = append(allErrs, e)
+		default:
+			break drainLoop
+		}
+	}
+
+	var combinedResults []byte
+	for _, res := range finalResults {
+		combinedResults = append(combinedResults, res...)
+	}
+
+	// We consider it a failure only if ALL targets returned an error AND we have targets,
+	// OR if it timed out and we gathered 0 successful results.
+	if len(allErrs) == targetsCount && targetsCount > 0 {
+		return nil, errors.Join(append([]error{errors.New("all targets failed")}, allErrs...)...)
+	}
+
+	if timeoutOccurred && len(finalResults) == 0 {
+		return nil, errors.New("timed out and no targets succeeded")
+	}
+
+	return combinedResults, nil
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -7,6 +7,95 @@ import (
 	"time"
 )
 
+func TestMiddlewares_Metrics(t *testing.T) {
+	n := node.NewBaseNode("metrics-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	metrics := &node.Metrics{}
+	n.Use(node.MetricsMiddleware(metrics))
+
+	var fail bool
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(10 * time.Millisecond)
+		if fail {
+			return nil, errors.New("simulated error")
+		}
+		return []byte("success"), nil
+	})
+
+	// 1. Successful request
+	res, err := n.Process([]byte("input1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(res) != "success" {
+		t.Errorf("expected success, got %s", string(res))
+	}
+
+	// 2. Failed request
+	fail = true
+	_, err = n.Process([]byte("input2"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if metrics.Invocations != 2 {
+		t.Errorf("expected 2 invocations, got %d", metrics.Invocations)
+	}
+	if metrics.Successes != 1 {
+		t.Errorf("expected 1 success, got %d", metrics.Successes)
+	}
+	if metrics.Failures != 1 {
+		t.Errorf("expected 1 failure, got %d", metrics.Failures)
+	}
+	if metrics.TotalProcessingTime < 20*1e6 { // 20ms in ns
+		t.Errorf("expected at least 20ms processing time, got %d ns", metrics.TotalProcessingTime)
+	}
+}
+
+func TestMiddlewares_RateLimiter(t *testing.T) {
+	n := node.NewBaseNode("rate-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	refillRate := 50 * time.Millisecond
+	n.Use(node.RateLimiterMiddleware(2, refillRate))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	// Consume tokens
+	_, err := n.Process([]byte("req1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = n.Process([]byte("req2"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Token bucket should be empty, expect rate limit error
+	_, err = n.Process([]byte("req3"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// Wait for 1 token to refill
+	time.Sleep(refillRate + 10*time.Millisecond)
+
+	_, err = n.Process([]byte("req4"))
+	if err != nil {
+		t.Fatalf("unexpected error after refill: %v", err)
+	}
+
+	// Token bucket should be empty again
+	_, err = n.Process([]byte("req5"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded again, got %v", err)
+	}
+}
+
 func TestMiddlewares_Logging(t *testing.T) {
 	n := node.NewBaseNode("log-node")
 	defer cleanupNodes(t, []node.Node{n})

--- a/node/tests/scatter_gather_node_test.go
+++ b/node/tests/scatter_gather_node_test.go
@@ -1,0 +1,111 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"testing"
+	"time"
+)
+
+func TestScatterGatherNode_Success(t *testing.T) {
+	n1 := node.NewBaseNode("t1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+
+	n2 := node.NewBaseNode("t2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+
+	sgn := node.NewScatterGatherNode("sg", 100*time.Millisecond)
+	sgn.AddTarget(n1)
+	sgn.AddTarget(n2)
+
+	defer cleanupNodes(t, []node.Node{n1, n2, sgn})
+
+	res, err := sgn.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resStr := string(res)
+	if resStr != "AB" && resStr != "BA" {
+		t.Errorf("expected combined results, got %s", resStr)
+	}
+}
+
+func TestScatterGatherNode_Timeout(t *testing.T) {
+	n1 := node.NewBaseNode("t1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+
+	n2 := node.NewBaseNode("t2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond) // Slow node
+		return []byte("B"), nil
+	})
+
+	// Timeout shorter than the slow node's sleep
+	sgn := node.NewScatterGatherNode("sg", 50*time.Millisecond)
+	sgn.AddTarget(n1)
+	sgn.AddTarget(n2)
+
+	defer cleanupNodes(t, []node.Node{n1, n2, sgn})
+
+	res, err := sgn.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("unexpected error on timeout partial success: %v", err)
+	}
+
+	if string(res) != "A" {
+		t.Errorf("expected only fast node's result, got %s", string(res))
+	}
+}
+
+func TestScatterGatherNode_AllFail(t *testing.T) {
+	n1 := node.NewBaseNode("t1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("err1")
+	})
+
+	n2 := node.NewBaseNode("t2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("err2")
+	})
+
+	sgn := node.NewScatterGatherNode("sg", 100*time.Millisecond)
+	sgn.AddTarget(n1)
+	sgn.AddTarget(n2)
+
+	defer cleanupNodes(t, []node.Node{n1, n2, sgn})
+
+	_, err := sgn.Process([]byte("input"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestScatterGatherNode_NoTargets(t *testing.T) {
+	sgn := node.NewScatterGatherNode("sg", 100*time.Millisecond)
+	defer cleanupNodes(t, []node.Node{sgn})
+
+	_, err := sgn.Process([]byte("input"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestScatterGatherNode_RemoveTarget(t *testing.T) {
+	n1 := node.NewBaseNode("t1")
+	sgn := node.NewScatterGatherNode("sg", 100*time.Millisecond)
+	sgn.AddTarget(n1)
+	sgn.RemoveTarget("t1")
+	defer cleanupNodes(t, []node.Node{n1, sgn})
+
+	_, err := sgn.Process([]byte("input"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}

--- a/node/tests/worker_pool_node_test.go
+++ b/node/tests/worker_pool_node_test.go
@@ -1,0 +1,85 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWorkerPoolNode_Success(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp", 2, 10)
+
+	var mu sync.Mutex
+	var processed [][]byte
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		mu.Lock()
+		defer mu.Unlock()
+		processed = append(processed, input)
+		return nil, nil
+	})
+
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{wp})
+
+	// Submit tasks
+	tasks := []string{"A", "B", "C"}
+	for _, task := range tasks {
+		_, err := wp.Process([]byte(task))
+		if err != nil {
+			t.Fatalf("unexpected error enqueueing: %v", err)
+		}
+	}
+
+	// Give workers time to process
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(processed) != 3 {
+		t.Errorf("expected 3 processed tasks, got %d", len(processed))
+	}
+}
+
+func TestWorkerPoolNode_QueueFull(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp", 1, 1)
+
+	// Block the worker so the queue fills up
+	// We'll use a wait group instead of blocking channels to avoid tests hanging
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		// Just sleep a tiny bit to simulate work, but allow it to finish
+		time.Sleep(100 * time.Millisecond)
+		return nil, nil
+	})
+
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	defer cleanupNodes(t, []node.Node{wp})
+
+	// 1. First task is pulled by worker immediately and takes 100ms
+	_, err := wp.Process([]byte("task1"))
+	if err != nil {
+		t.Fatalf("unexpected error enqueueing task1: %v", err)
+	}
+
+	time.Sleep(10 * time.Millisecond) // Let worker pull it
+
+	// 2. Second task fills the queue of size 1
+	_, err = wp.Process([]byte("task2"))
+	if err != nil {
+		t.Fatalf("unexpected error enqueueing task2: %v", err)
+	}
+
+	// 3. We immediately try to submit a third task. Since the queue of size 1 is full,
+	// and the worker is busy sleeping, this should immediately fail
+	_, err = wp.Process([]byte("task3"))
+	if !errors.Is(err, node.ErrQueueFull) {
+		t.Fatalf("expected ErrQueueFull, got %v", err)
+	}
+}

--- a/node/worker_pool_node.go
+++ b/node/worker_pool_node.go
@@ -1,0 +1,101 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// ErrQueueFull is returned when the worker pool's job queue is full.
+var ErrQueueFull = errors.New("worker pool job queue is full")
+
+// WorkerPoolNode uses a fixed pool of goroutines to process incoming data asynchronously.
+type WorkerPoolNode struct {
+	*BaseNode
+	jobQueue chan []byte
+	workers  int
+	wg       sync.WaitGroup
+	ctx      context.Context
+	cancel   context.CancelFunc
+}
+
+// NewWorkerPoolNode creates a new WorkerPoolNode with the specified number of workers and queue size.
+func NewWorkerPoolNode(id string, workers int, queueSize int) *WorkerPoolNode {
+	ctx, cancel := context.WithCancel(context.Background())
+	wp := &WorkerPoolNode{
+		BaseNode: NewBaseNode(id),
+		jobQueue: make(chan []byte, queueSize),
+		workers:  workers,
+		ctx:      ctx,
+		cancel:   cancel,
+	}
+
+	return wp
+}
+
+// Process overrides BaseNode.Process to handle non-blocking insertion of tasks into the pool.
+// Middlewares and actual process logic will be executed by the workers.
+func (wp *WorkerPoolNode) Process(input []byte) ([]byte, error) {
+	// Clone input to prevent data races, since processing is async
+	inputCopy := make([]byte, len(input))
+	copy(inputCopy, input)
+
+	select {
+	case <-wp.ctx.Done():
+		return nil, errors.New("worker pool is shutting down")
+	case wp.jobQueue <- inputCopy:
+		// Job successfully enqueued
+		return nil, nil // Return nil, nil because the real result is processed asynchronously
+	default:
+		return nil, ErrQueueFull
+	}
+}
+
+// Create starts the background worker goroutines.
+func (wp *WorkerPoolNode) Create() error {
+	if err := wp.BaseNode.Create(); err != nil {
+		return err
+	}
+
+	for i := 0; i < wp.workers; i++ {
+		wp.wg.Add(1)
+		go wp.worker()
+	}
+	return nil
+}
+
+// Delete gracefully shuts down the worker pool and cleans up.
+func (wp *WorkerPoolNode) Delete() error {
+	// Signal workers to stop
+	wp.cancel()
+
+	// Wait for workers to finish
+	wp.wg.Wait()
+
+	// Safely drain the job channel without closing it
+drainLoop:
+	for {
+		select {
+		case <-wp.jobQueue:
+			// drain
+		default:
+			break drainLoop
+		}
+	}
+
+	return wp.BaseNode.Delete()
+}
+
+// worker reads from the job queue and processes the input until context is cancelled.
+func (wp *WorkerPoolNode) worker() {
+	defer wp.wg.Done()
+	for {
+		select {
+		case <-wp.ctx.Done():
+			return
+		case job := <-wp.jobQueue:
+			// Note: This relies on BaseNode.Process to correctly invoke any middlewares and user logic.
+			wp.BaseNode.Process(job)
+		}
+	}
+}


### PR DESCRIPTION
Implemented new powerful middlewares (Metrics, RateLimiter) and node types (ScatterGather, WorkerPool) to enhance the modularity and capabilities of the framework.

---
*PR created automatically by Jules for task [17140685759733152861](https://jules.google.com/task/17140685759733152861) started by @lhemerly*