### PR TITLE
feat: add scatter-gather node, rate limiter, and metrics middlewares

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +59,69 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimiterMiddleware limits the rate of processing using a token bucket algorithm.
+func RateLimiterMiddleware(rate float64, burst int) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64   = float64(burst)
+		lastUpdate time.Time = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+			now := time.Now()
+			elapsed := now.Sub(lastUpdate).Seconds()
+
+			tokens += elapsed * rate
+			if tokens > float64(burst) {
+				tokens = float64(burst)
+			}
+			lastUpdate = now
+
+			if tokens >= 1 {
+				tokens--
+				mu.Unlock()
+				return next(input)
+			}
+			mu.Unlock()
+
+			return nil, ErrRateLimitExceeded
+		}
+	}
+}
+
+// MetricsTracker holds the atomic counters for the MetricsMiddleware.
+type MetricsTracker struct {
+	Invocations    uint64
+	Successes      uint64
+	Failures       uint64
+	TotalTimeNanos int64
+}
+
+// MetricsMiddleware tracks invocations, successes, failures, and execution time.
+func MetricsMiddleware(tracker *MetricsTracker) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			atomic.AddUint64(&tracker.Invocations, 1)
+			start := time.Now()
+
+			output, err := next(input)
+
+			duration := time.Since(start).Nanoseconds()
+			atomic.AddInt64(&tracker.TotalTimeNanos, duration)
+
+			if err != nil {
+				atomic.AddUint64(&tracker.Failures, 1)
+			} else {
+				atomic.AddUint64(&tracker.Successes, 1)
+			}
+
+			return output, err
 		}
 	}
 }

--- a/node/scatter_gather_node.go
+++ b/node/scatter_gather_node.go
@@ -1,0 +1,152 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	ErrScatterGatherTimeout = errors.New("scatter gather operation timed out")
+	ErrNoTargets            = errors.New("no target nodes configured for scatter gather")
+)
+
+// ScatterGatherNode concurrently broadcasts an input to multiple target nodes
+// and gathers their results. It includes a timeout mechanism.
+type ScatterGatherNode struct {
+	*BaseNode
+	targetsMutex sync.RWMutex
+	targets      []Node
+	timeout      time.Duration
+}
+
+// NewScatterGatherNode creates a new ScatterGatherNode with a specific timeout.
+func NewScatterGatherNode(id string, timeout time.Duration) *ScatterGatherNode {
+	sgn := &ScatterGatherNode{
+		BaseNode: NewBaseNode(id),
+		targets:  make([]Node, 0),
+		timeout:  timeout,
+	}
+	sgn.SetProcessFunc(sgn.scatterGather)
+	return sgn
+}
+
+// AddTarget adds a node to the scatter targets list.
+func (sgn *ScatterGatherNode) AddTarget(node Node) {
+	sgn.targetsMutex.Lock()
+	defer sgn.targetsMutex.Unlock()
+	sgn.targets = append(sgn.targets, node)
+}
+
+// RemoveTarget removes a node from the scatter targets list by its ID.
+func (sgn *ScatterGatherNode) RemoveTarget(nodeID string) {
+	sgn.targetsMutex.Lock()
+	defer sgn.targetsMutex.Unlock()
+
+	for i, target := range sgn.targets {
+		if target.GetID() == nodeID {
+			sgn.targets = append(sgn.targets[:i], sgn.targets[i+1:]...)
+			break
+		}
+	}
+}
+
+// GetTargets returns a copy of the current target nodes list.
+func (sgn *ScatterGatherNode) GetTargets() []Node {
+	sgn.targetsMutex.RLock()
+	defer sgn.targetsMutex.RUnlock()
+
+	targetsCopy := make([]Node, len(sgn.targets))
+	copy(targetsCopy, sgn.targets)
+	return targetsCopy
+}
+
+type scatterResult struct {
+	nodeID string
+	output []byte
+	err    error
+}
+
+// scatterGather processes the input by concurrently sending it to all target nodes.
+func (sgn *ScatterGatherNode) scatterGather(input []byte) ([]byte, error) {
+	targets := sgn.GetTargets()
+	if len(targets) == 0 {
+		return nil, ErrNoTargets
+	}
+
+	resultsChan := make(chan scatterResult, len(targets))
+	var wg sync.WaitGroup
+
+	ctx, cancel := context.WithTimeout(context.Background(), sgn.timeout)
+	defer cancel()
+
+	for _, target := range targets {
+		wg.Add(1)
+		go func(t Node) {
+			defer wg.Done()
+
+			// Deep copy input for each goroutine to prevent data races
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			out, err := t.Process(inputCopy)
+			resultsChan <- scatterResult{
+				nodeID: t.GetID(),
+				output: out,
+				err:    err,
+			}
+		}(target)
+	}
+
+	// Wait for all workers to finish
+	doneChan := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneChan)
+	}()
+
+	var combinedResults []byte
+	var finalErr error
+	var errs []error
+	var timeoutOccurred bool
+
+	select {
+	case <-doneChan:
+		// All targets finished within the timeout
+	case <-ctx.Done():
+		// Timeout occurred before all targets finished
+		timeoutOccurred = true
+	}
+
+	// Drain results channel without blocking
+	// The channel is never closed by workers to prevent panics, GC will collect it.
+drainLoop:
+	for {
+		select {
+		case res := <-resultsChan:
+			if res.err != nil {
+				errs = append(errs, res.err)
+			} else {
+				if res.output != nil {
+					combinedResults = append(combinedResults, res.output...)
+				}
+			}
+		default:
+			break drainLoop
+		}
+	}
+
+	if timeoutOccurred {
+		if len(errs) > 0 {
+			errs = append(errs, ErrScatterGatherTimeout)
+			finalErr = errors.Join(errs...)
+		} else {
+			finalErr = ErrScatterGatherTimeout
+		}
+	} else if len(errs) > 0 {
+		finalErr = errors.Join(errs...)
+	}
+
+	return combinedResults, finalErr
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -2,9 +2,10 @@ package node_test
 
 import (
 	"errors"
-	"github.com/lhemerly/Constellation/node"
 	"testing"
 	"time"
+
+	"github.com/lhemerly/Constellation/node"
 )
 
 func TestMiddlewares_Logging(t *testing.T) {
@@ -312,5 +313,85 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 	_, err = n.Process([]byte{})
 	if !errors.Is(err, node.ErrCircuitBreakerOpen) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
+	}
+}
+
+func TestMiddlewares_RateLimiter(t *testing.T) {
+	n := node.NewBaseNode("rate-limiter-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// Rate of 10 tokens per second (1 token per 100ms), burst of 2
+	n.Use(node.RateLimiterMiddleware(10, 2))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	// First two requests should pass due to burst capacity
+	_, err := n.Process([]byte("input1"))
+	if err != nil {
+		t.Fatalf("expected first request to succeed, got %v", err)
+	}
+
+	_, err = n.Process([]byte("input2"))
+	if err != nil {
+		t.Fatalf("expected second request to succeed, got %v", err)
+	}
+
+	// Third request immediately should fail
+	_, err = n.Process([]byte("input3"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// Wait enough time for 1 token to regenerate (> 100ms)
+	time.Sleep(150 * time.Millisecond)
+
+	_, err = n.Process([]byte("input4"))
+	if err != nil {
+		t.Fatalf("expected fourth request to succeed after waiting, got %v", err)
+	}
+}
+
+func TestMiddlewares_Metrics(t *testing.T) {
+	n := node.NewBaseNode("metrics-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	tracker := &node.MetricsTracker{}
+	n.Use(node.MetricsMiddleware(tracker))
+
+	var fail bool
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(10 * time.Millisecond)
+		if fail {
+			return nil, errors.New("simulated error")
+		}
+		return []byte("success"), nil
+	})
+
+	// Process one successful request
+	_, err := n.Process([]byte("input1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Process one failing request
+	fail = true
+	_, err = n.Process([]byte("input2"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if tracker.Invocations != 2 {
+		t.Errorf("expected 2 invocations, got %d", tracker.Invocations)
+	}
+	if tracker.Successes != 1 {
+		t.Errorf("expected 1 success, got %d", tracker.Successes)
+	}
+	if tracker.Failures != 1 {
+		t.Errorf("expected 1 failure, got %d", tracker.Failures)
+	}
+	if tracker.TotalTimeNanos <= 0 {
+		t.Errorf("expected TotalTimeNanos > 0, got %d", tracker.TotalTimeNanos)
 	}
 }

--- a/node/tests/scatter_gather_test.go
+++ b/node/tests/scatter_gather_test.go
@@ -1,0 +1,112 @@
+package node_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestScatterGatherNode_Success(t *testing.T) {
+	sgn := node.NewScatterGatherNode("sg-success", 500*time.Millisecond)
+	defer cleanupNodes(t, []node.Node{sgn})
+
+	target1 := node.NewBaseNode("t1")
+	target1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("t1-"), input...), nil
+	})
+	defer cleanupNodes(t, []node.Node{target1})
+
+	target2 := node.NewBaseNode("t2")
+	target2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("t2-"), input...), nil
+	})
+	defer cleanupNodes(t, []node.Node{target2})
+
+	sgn.AddTarget(target1)
+	sgn.AddTarget(target2)
+
+	res, err := sgn.Process([]byte("data"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resStr := string(res)
+	if !strings.Contains(resStr, "t1-data") || !strings.Contains(resStr, "t2-data") {
+		t.Errorf("expected results from both targets, got %s", resStr)
+	}
+}
+
+func TestScatterGatherNode_PartialTimeout(t *testing.T) {
+	sgn := node.NewScatterGatherNode("sg-timeout", 100*time.Millisecond)
+	defer cleanupNodes(t, []node.Node{sgn})
+
+	target1 := node.NewBaseNode("t1")
+	target1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("t1-"), input...), nil
+	})
+	defer cleanupNodes(t, []node.Node{target1})
+
+	target2 := node.NewBaseNode("t2")
+	target2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		// Use a signal channel instead of sleep to avoid blocking Delete()
+		blockCh := make(chan struct{})
+		// Do not wait forever, wait more than timeout but less than test total timeout to allow clean up
+		select {
+		case <-time.After(300 * time.Millisecond):
+		case <-blockCh:
+		}
+		return append([]byte("t2-"), input...), nil
+	})
+	defer cleanupNodes(t, []node.Node{target2})
+
+	sgn.AddTarget(target1)
+	sgn.AddTarget(target2)
+
+	res, err := sgn.Process([]byte("data"))
+
+	if err == nil {
+		t.Fatalf("expected error from timeout, got nil")
+	}
+
+	if !errors.Is(err, node.ErrScatterGatherTimeout) {
+		t.Errorf("expected ErrScatterGatherTimeout, got %v", err)
+	}
+
+	resStr := string(res)
+	if !strings.Contains(resStr, "t1-data") {
+		t.Errorf("expected partial result from t1, got %s", resStr)
+	}
+}
+
+func TestScatterGatherNode_AllErrors(t *testing.T) {
+	sgn := node.NewScatterGatherNode("sg-errors", 500*time.Millisecond)
+	defer cleanupNodes(t, []node.Node{sgn})
+
+	target1 := node.NewBaseNode("t1")
+	target1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("err1")
+	})
+	defer cleanupNodes(t, []node.Node{target1})
+
+	target2 := node.NewBaseNode("t2")
+	target2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("err2")
+	})
+	defer cleanupNodes(t, []node.Node{target2})
+
+	sgn.AddTarget(target1)
+	sgn.AddTarget(target2)
+
+	_, err := sgn.Process([]byte("data"))
+	if err == nil {
+		t.Fatalf("expected combined errors, got nil")
+	}
+
+	errStr := err.Error()
+	if !strings.Contains(errStr, "err1") || !strings.Contains(errStr, "err2") {
+		t.Errorf("expected error to contain err1 and err2, got %s", errStr)
+	}
+}


### PR DESCRIPTION
Added advanced middlewares and a ScatterGatherNode implementation to the Constellation framework based on a creative brainstorming session. 

**ScatterGatherNode**
- Broadcasts inputs concurrently to a slice of target nodes.
- Manages an internal context timeout for aggregation, preventing long-running nodes from holding up the pipeline.
- Handles partial results and specific `ErrScatterGatherTimeout` states perfectly.
- Eliminates potential data races by deep copying byte slice inputs for each worker goroutine.

**RateLimiterMiddleware**
- Allows setting a specific allowed rate and burst limit using a token bucket approach.
- Optimized avoiding background `time.Ticker` goroutines, using calculation-on-demand with mutexes to prevent memory leaks.

**MetricsMiddleware**
- Easily hooks into a shared `MetricsTracker` to extract atomic counters on latency and request success/failures.

All modifications comply with strict formatting and testing constraints, verified by `go vet` and robust unit tests with `go test ./...`.

---
*PR created automatically by Jules for task [16405900719559681974](https://jules.google.com/task/16405900719559681974) started by @lhemerly*