### PR TITLE
docs: fix missing transport credentials in gRPC README example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,10 @@ import (
     "context"
     "fmt"
     "log"
+
     "github.com/lhemerly/Constellation/connection"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -155,7 +158,7 @@ func main() {
     ctx := context.Background()
 
     // Create a new gRPC connection
-    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to create connection: %v", err)
     }


### PR DESCRIPTION
Updates the gRPC usage example in `readme.md` to properly configure transport security (`insecure.NewCredentials()`) as required by recent gRPC library versions. The previous example would fail at runtime. Also adds the necessary gRPC imports to make the code snippet functional.

Also reviewed all node, connection, and event types mentioned in the README and verified they are all present and fully implemented in the codebase (no missing functionality).

---
*PR created automatically by Jules for task [11083600642003883388](https://jules.google.com/task/11083600642003883388) started by @lhemerly*