### PR TITLE
docs: Fix incorrect filenames in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,8 +198,8 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 
-This project is licensed under the MIT License. See the `LICENSE` file for details.
+This project is licensed under the MIT License. See the `LICENSE.md` file for details.


### PR DESCRIPTION
This PR updates `readme.md` to reference the correct filenames for the contribution guidelines (`CONTRIBUTE.md` instead of `CONTRIBUTING.md`) and the project license (`LICENSE.md` instead of `LICENSE`), ensuring that readers and contributors can find the necessary project documentation successfully.

---
*PR created automatically by Jules for task [2445055569987668607](https://jules.google.com/task/2445055569987668607) started by @lhemerly*