### PR TITLE
docs: fix contributing filename reference in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -198,7 +198,7 @@ The project is designed to be easily extensible:
 
 ## Contributing
 
-Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTING.md` file for guidelines on how to contribute.
+Contributions to the Constellation project are welcome! Please refer to the `CONTRIBUTE.md` file for guidelines on how to contribute.
 
 ## License
 


### PR DESCRIPTION
Fixes the incorrect file reference for `CONTRIBUTE.md` in the `readme.md`.

---
*PR created automatically by Jules for task [12833582549657215061](https://jules.google.com/task/12833582549657215061) started by @lhemerly*