### PR TITLE
feat: Add new node types and middlewares

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +59,70 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimiterMiddleware limits the number of requests per second using a token bucket algorithm.
+func RateLimiterMiddleware(rate float64, burst int) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64   = float64(burst)
+		lastRefill time.Time = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+
+			now := time.Now()
+			elapsed := now.Sub(lastRefill).Seconds()
+			tokens += elapsed * rate
+			if tokens > float64(burst) {
+				tokens = float64(burst)
+			}
+			lastRefill = now
+
+			if tokens >= 1 {
+				tokens--
+				mu.Unlock()
+				return next(input)
+			}
+
+			mu.Unlock()
+			return nil, ErrRateLimitExceeded
+		}
+	}
+}
+
+// Metrics captures telemetry data for node processing.
+type Metrics struct {
+	ActiveRequests uint64
+	TotalSuccess   uint64
+	TotalFailures  uint64
+	TotalDuration  int64 // in nanoseconds
+}
+
+// MetricsMiddleware tracks metrics such as active requests, successes, failures, and total processing duration.
+func MetricsMiddleware(metrics *Metrics) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			atomic.AddUint64(&metrics.ActiveRequests, 1)
+			defer atomic.AddUint64(&metrics.ActiveRequests, ^uint64(0)) // decrement
+
+			start := time.Now()
+			output, err := next(input)
+			duration := time.Since(start).Nanoseconds()
+
+			atomic.AddInt64(&metrics.TotalDuration, duration)
+
+			if err != nil {
+				atomic.AddUint64(&metrics.TotalFailures, 1)
+			} else {
+				atomic.AddUint64(&metrics.TotalSuccess, 1)
+			}
+
+			return output, err
 		}
 	}
 }

--- a/node/scatter_gather_node.go
+++ b/node/scatter_gather_node.go
@@ -1,0 +1,141 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrScatterGatherTimeout is returned when the scatter-gather operation times out.
+var ErrScatterGatherTimeout = errors.New("scatter-gather operation timed out")
+
+// ScatterGatherNode broadcasts a request to multiple destination nodes and gathers their results.
+type ScatterGatherNode struct {
+	*BaseNode
+	nodesMutex sync.RWMutex
+	nodes      []Node
+	timeout    time.Duration
+}
+
+// NewScatterGatherNode creates a new ScatterGatherNode.
+func NewScatterGatherNode(id string, timeout time.Duration) *ScatterGatherNode {
+	sg := &ScatterGatherNode{
+		BaseNode: NewBaseNode(id),
+		timeout:  timeout,
+		nodes:    make([]Node, 0),
+	}
+	// Note: We don't use SetProcessFunc here, we override Process directly.
+	return sg
+}
+
+// AddNode adds a destination node to the scatter-gather pool.
+func (sg *ScatterGatherNode) AddNode(node Node) {
+	sg.nodesMutex.Lock()
+	defer sg.nodesMutex.Unlock()
+	sg.nodes = append(sg.nodes, node)
+}
+
+// GetNodes returns the current list of destination nodes.
+func (sg *ScatterGatherNode) GetNodes() []Node {
+	sg.nodesMutex.RLock()
+	defer sg.nodesMutex.RUnlock()
+
+	nodesCopy := make([]Node, len(sg.nodes))
+	copy(nodesCopy, sg.nodes)
+	return nodesCopy
+}
+
+// Process scatters the input to all destination nodes and gathers their results within the timeout.
+func (sg *ScatterGatherNode) Process(input []byte) ([]byte, error) {
+	// First, run our own BaseNode process (for middlewares/metrics)
+	_, err := sg.BaseNode.Process(input)
+	if err != nil {
+		return nil, err
+	}
+
+	targets := sg.GetNodes()
+	if len(targets) == 0 {
+		return nil, errors.New("no destination nodes available")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), sg.timeout)
+	defer cancel()
+
+	type result struct {
+		nodeID string
+		output []byte
+		err    error
+	}
+
+	resultChan := make(chan result, len(targets))
+	var wg sync.WaitGroup
+
+	for _, n := range targets {
+		wg.Add(1)
+		go func(targetNode Node) {
+			defer wg.Done()
+
+			// Clone input to prevent data races
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			output, err := targetNode.Process(inputCopy)
+			resultChan <- result{
+				nodeID: targetNode.GetID(),
+				output: output,
+				err:    err,
+			}
+		}(n)
+	}
+
+	// Wait for all workers to finish
+	doneChan := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneChan)
+	}()
+
+	var allErrors error
+	var gatheredOutput []byte
+	timeoutOccurred := false
+
+	select {
+	case <-doneChan:
+		// All nodes finished before timeout
+	case <-ctx.Done():
+		// Timeout occurred
+		timeoutOccurred = true
+	}
+
+	// We do NOT close resultChan here because in the event of a timeout,
+	// background workers might still be executing and will panic if they
+	// try to send to a closed channel. The channel is fully buffered to
+	// len(targets), so the background workers will not block on send.
+
+	// Drain all currently available results without blocking.
+drainLoop:
+	for {
+		select {
+		case res := <-resultChan:
+			if res.err != nil {
+				allErrors = errors.Join(allErrors, res.err)
+			} else {
+				// Append results simply for this example
+				gatheredOutput = append(gatheredOutput, res.output...)
+			}
+		default:
+			break drainLoop
+		}
+	}
+
+	if timeoutOccurred {
+		return gatheredOutput, errors.Join(allErrors, ErrScatterGatherTimeout)
+	}
+
+	if allErrors != nil && len(gatheredOutput) == 0 {
+		return nil, allErrors
+	}
+
+	return gatheredOutput, allErrors
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -314,3 +314,69 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
 	}
 }
+
+func TestMiddlewares_RateLimiter(t *testing.T) {
+	n := node.NewBaseNode("rate-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// Allow 1 request per second, with a burst of 2
+	n.Use(node.RateLimiterMiddleware(1, 2))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return input, nil
+	})
+
+	// Should pass (consumes 1 token, 1 remaining)
+	_, err := n.Process([]byte("req1"))
+	if err != nil {
+		t.Fatalf("expected no error for req1, got %v", err)
+	}
+
+	// Should pass (consumes 1 token, 0 remaining)
+	_, err = n.Process([]byte("req2"))
+	if err != nil {
+		t.Fatalf("expected no error for req2, got %v", err)
+	}
+
+	// Should fail (no tokens)
+	_, err = n.Process([]byte("req3"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded for req3, got %v", err)
+	}
+}
+
+func TestMiddlewares_Metrics(t *testing.T) {
+	n := node.NewBaseNode("metrics-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	metrics := &node.Metrics{}
+	n.Use(node.MetricsMiddleware(metrics))
+
+	failProcess := false
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		if failProcess {
+			return nil, errors.New("simulated error")
+		}
+		return input, nil
+	})
+
+	// 1 success
+	_, _ = n.Process([]byte("success"))
+
+	// 1 failure
+	failProcess = true
+	_, _ = n.Process([]byte("failure"))
+
+	if metrics.TotalSuccess != 1 {
+		t.Errorf("expected 1 success, got %d", metrics.TotalSuccess)
+	}
+	if metrics.TotalFailures != 1 {
+		t.Errorf("expected 1 failure, got %d", metrics.TotalFailures)
+	}
+	if metrics.ActiveRequests != 0 {
+		t.Errorf("expected 0 active requests, got %d", metrics.ActiveRequests)
+	}
+	if metrics.TotalDuration <= 0 {
+		t.Errorf("expected TotalDuration > 0, got %d", metrics.TotalDuration)
+	}
+}

--- a/node/tests/scatter_gather_node_test.go
+++ b/node/tests/scatter_gather_node_test.go
@@ -1,0 +1,99 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestScatterGatherNode_Basic(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg1", 2*time.Second)
+
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("n1:"), input...), nil
+	})
+
+	n2 := node.NewBaseNode("n2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("n2:"), input...), nil
+	})
+
+	sg.AddNode(n1)
+	sg.AddNode(n2)
+
+	defer cleanupNodes(t, []node.Node{sg, n1, n2})
+
+	output, err := sg.Process([]byte("data"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	outStr := string(output)
+	if !strings.Contains(outStr, "n1:data") || !strings.Contains(outStr, "n2:data") {
+		t.Errorf("expected output to contain both n1:data and n2:data, got %s", outStr)
+	}
+}
+
+func TestScatterGatherNode_Timeout(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg2", 100*time.Millisecond)
+
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("fast"), nil
+	})
+
+	n2 := node.NewBaseNode("n2")
+	blockCh := make(chan struct{})
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		<-blockCh
+		return []byte("slow"), nil
+	})
+	defer close(blockCh)
+
+	sg.AddNode(n1)
+	sg.AddNode(n2)
+
+	defer cleanupNodes(t, []node.Node{sg, n1, n2})
+
+	output, err := sg.Process([]byte("data"))
+
+	if !errors.Is(err, node.ErrScatterGatherTimeout) {
+		t.Fatalf("expected ErrScatterGatherTimeout, got %v", err)
+	}
+
+	// Should have gathered partial results
+	if string(output) != "fast" {
+		t.Errorf("expected partial output 'fast', got %s", string(output))
+	}
+}
+
+func TestScatterGatherNode_Errors(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg3", 2*time.Second)
+
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("error from n1")
+	})
+
+	sg.AddNode(n1)
+	defer cleanupNodes(t, []node.Node{sg, n1})
+
+	_, err := sg.Process([]byte("data"))
+
+	if err == nil || !strings.Contains(err.Error(), "error from n1") {
+		t.Fatalf("expected error from n1, got %v", err)
+	}
+}
+
+func TestScatterGatherNode_NoNodes(t *testing.T) {
+	sg := node.NewScatterGatherNode("sg4", 2*time.Second)
+	defer cleanupNodes(t, []node.Node{sg})
+
+	_, err := sg.Process([]byte("data"))
+	if err == nil || err.Error() != "no destination nodes available" {
+		t.Fatalf("expected no destination nodes available error, got %v", err)
+	}
+}

--- a/node/tests/worker_pool_node_test.go
+++ b/node/tests/worker_pool_node_test.go
@@ -1,0 +1,103 @@
+package node_test
+
+import (
+	"errors"
+	"github.com/lhemerly/Constellation/node"
+	"testing"
+	"time"
+)
+
+func TestWorkerPoolNode_Basic(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp1", 2, 5)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create worker pool: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{wp})
+
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("processed: "), input...), nil
+	})
+
+	output, err := wp.Process([]byte("task1"))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if string(output) != "processed: task1" {
+		t.Errorf("expected 'processed: task1', got '%s'", string(output))
+	}
+}
+
+func TestWorkerPoolNode_QueueFull(t *testing.T) {
+	// 1 worker, queue size 1
+	wp := node.NewWorkerPoolNode("wp2", 1, 1)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create worker pool: %v", err)
+	}
+	defer cleanupNodes(t, []node.Node{wp})
+
+	blockCh := make(chan struct{})
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		<-blockCh // block the worker indefinitely
+		return input, nil
+	})
+
+	// Ensure we don't deadlock teardown
+	defer close(blockCh)
+
+	// Dispatch task 1 (will be picked up by the single worker and block)
+	go wp.Process([]byte("task1"))
+
+	// Small sleep to ensure worker has picked up the task from the queue
+	time.Sleep(50 * time.Millisecond)
+
+	// Dispatch task 2 (will go into the queue of size 1)
+	go wp.Process([]byte("task2"))
+
+	// Small sleep to ensure task2 is in the queue
+	time.Sleep(50 * time.Millisecond)
+
+	// Dispatch task 3 (should fail because queue is full)
+	_, err := wp.Process([]byte("task3"))
+	if !errors.Is(err, node.ErrQueueFull) {
+		t.Fatalf("expected ErrQueueFull, got %v", err)
+	}
+}
+
+func TestWorkerPoolNode_Teardown(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp3", 2, 5)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("failed to create worker pool: %v", err)
+	}
+
+	blockCh := make(chan struct{})
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		<-blockCh
+		return input, nil
+	})
+
+	// Dispatch a task
+	resChan := make(chan error, 1)
+	go func() {
+		_, err := wp.Process([]byte("task1"))
+		resChan <- err
+	}()
+
+	time.Sleep(50 * time.Millisecond) // Give worker time to pick up task
+
+	// Shut down before unblocking
+	go func() {
+		wp.Delete()
+	}()
+
+	time.Sleep(50 * time.Millisecond) // Give delete time to initiate
+
+	// Unblock worker
+	close(blockCh)
+
+	// The task could either succeed (if it finished just before shutdown killed it)
+	// or return an error. The key is it shouldn't deadlock or panic.
+	err := <-resChan
+	if err != nil && err.Error() != "worker pool shut down before processing completed" {
+		t.Logf("task failed with expected shutdown error: %v", err)
+	}
+}

--- a/node/worker_pool_node.go
+++ b/node/worker_pool_node.go
@@ -1,0 +1,140 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// ErrQueueFull is returned when the WorkerPoolNode's task queue is full.
+var ErrQueueFull = errors.New("task queue is full")
+
+type workerTask struct {
+	input      []byte
+	resultChan chan struct {
+		output []byte
+		err    error
+	}
+}
+
+// WorkerPoolNode manages a pool of worker goroutines that process tasks concurrently.
+type WorkerPoolNode struct {
+	*BaseNode
+	workers    int
+	queueSize  int
+	taskQueue  chan workerTask
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+	wg         sync.WaitGroup
+}
+
+// NewWorkerPoolNode creates a new WorkerPoolNode.
+func NewWorkerPoolNode(id string, workers, queueSize int) *WorkerPoolNode {
+	ctx, cancel := context.WithCancel(context.Background())
+	wp := &WorkerPoolNode{
+		BaseNode:   NewBaseNode(id),
+		workers:    workers,
+		queueSize:  queueSize,
+		taskQueue:  make(chan workerTask, queueSize),
+		ctx:        ctx,
+		cancelFunc: cancel,
+	}
+
+	// We don't use SetProcessFunc here because we want to intercept the entire
+	// Process call to enqueue it, but we still need the BaseNode.Process to execute
+	// so that middlewares, eventCounter, and processFunc are invoked properly by the workers.
+	return wp
+}
+
+// Create spawns the worker pool goroutines.
+func (n *WorkerPoolNode) Create() error {
+	for i := 0; i < n.workers; i++ {
+		n.wg.Add(1)
+		go n.worker()
+	}
+	return n.BaseNode.Create()
+}
+
+func (n *WorkerPoolNode) worker() {
+	defer n.wg.Done()
+	for {
+		select {
+		case <-n.ctx.Done():
+			return
+		case task, ok := <-n.taskQueue:
+			if !ok {
+				return
+			}
+			// Clone input to prevent data races if modified by caller
+			inputCopy := make([]byte, len(task.input))
+			copy(inputCopy, task.input)
+
+			// Invoke BaseNode.Process to trigger middlewares and actual processFunc
+			output, err := n.BaseNode.Process(inputCopy)
+			task.resultChan <- struct {
+				output []byte
+				err    error
+			}{output, err}
+		}
+	}
+}
+
+// Process enqueues a task for the worker pool and waits for the result.
+func (n *WorkerPoolNode) Process(input []byte) ([]byte, error) {
+	// First, check for shutdown signal to avoid pseudo-random select
+	select {
+	case <-n.ctx.Done():
+		return nil, errors.New("worker pool is shutting down")
+	default:
+	}
+
+	resultChan := make(chan struct {
+		output []byte
+		err    error
+	}, 1)
+
+	task := workerTask{
+		input:      input,
+		resultChan: resultChan,
+	}
+
+	// Try to enqueue the task
+	select {
+	case n.taskQueue <- task:
+		// Wait for the result or context cancellation
+		select {
+		case res := <-resultChan:
+			return res.output, res.err
+		case <-n.ctx.Done():
+			return nil, errors.New("worker pool shut down before processing completed")
+		}
+	case <-n.ctx.Done():
+		return nil, errors.New("worker pool is shutting down")
+	default:
+		return nil, ErrQueueFull
+	}
+}
+
+// Delete gracefully shuts down the worker pool.
+func (n *WorkerPoolNode) Delete() error {
+	// Cancel the context to signal workers to stop reading from the queue and shutdown
+	n.cancelFunc()
+
+	// Wait for all workers to finish currently executing tasks
+	n.wg.Wait()
+
+	// Safe to close the channel now that no workers are reading and Process will fail-fast
+	close(n.taskQueue)
+
+	// Drain the queue to unblock any pending tasks
+	for task := range n.taskQueue {
+		if task.resultChan != nil {
+			task.resultChan <- struct {
+				output []byte
+				err    error
+			}{nil, errors.New("worker pool shut down before processing")}
+		}
+	}
+
+	return n.BaseNode.Delete()
+}


### PR DESCRIPTION
## Description
Added new middlewares (`RateLimiterMiddleware`, `MetricsMiddleware`) and nodes (`WorkerPoolNode`, `ScatterGatherNode`) to improve the capabilities of the graph-processing framework. All additions include robust tests focusing on thread-safety, edge-case timeouts, and graceful shutdown.

---
*PR created automatically by Jules for task [4745529658856479737](https://jules.google.com/task/4745529658856479737) started by @lhemerly*