### PR TITLE
Fix gRPC Connection usage example in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,8 @@ import (
     "fmt"
     "log"
     "github.com/lhemerly/Constellation/connection"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -155,7 +157,7 @@ func main() {
     ctx := context.Background()
 
     // Create a new gRPC connection
-    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to create connection: %v", err)
     }


### PR DESCRIPTION
Updates the `readme.md` gRPC connection example by explicitly importing `google.golang.org/grpc` and `google.golang.org/grpc/credentials/insecure` and adding `grpc.WithTransportCredentials(insecure.NewCredentials())` to `factory.NewConnection`. This is necessary for newer versions of `grpc-go` where connections without transport credentials set will fail by default.

---
*PR created automatically by Jules for task [15315058387050193989](https://jules.google.com/task/15315058387050193989) started by @lhemerly*