### PR TITLE
docs: update grpc connection example with required credentials

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,8 @@ import (
     "fmt"
     "log"
     "github.com/lhemerly/Constellation/connection"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -155,7 +157,7 @@ func main() {
     ctx := context.Background()
 
     // Create a new gRPC connection
-    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to create connection: %v", err)
     }


### PR DESCRIPTION
docs: update grpc connection example with required credentials

Newer versions of grpc require explicit transport credentials set
for connections to be established, otherwise they fail with a
"no transport security set" error. The gRPC example in readme.md
has been updated to include `grpc.WithTransportCredentials(insecure.NewCredentials())`
and necessary imports to ensure the snippet actually works out of the box.

---
*PR created automatically by Jules for task [14978775217075544959](https://jules.google.com/task/14978775217075544959) started by @lhemerly*