### PR TITLE
feat: add RateLimit and Metrics middlewares

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -207,6 +209,75 @@ func CircuitBreakerMiddleware(maxFailures int, cooldown time.Duration) Middlewar
 			} else {
 				failures = 0
 				state = 0 // Closed
+			}
+
+			return output, err
+		}
+	}
+}
+
+// RateLimitMiddleware limits the rate of processes using a token bucket algorithm.
+func RateLimitMiddleware(rate time.Duration, burst int) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64
+		lastRefill time.Time
+	)
+
+	tokens = float64(burst)
+	lastRefill = time.Now()
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+
+			now := time.Now()
+			elapsed := now.Sub(lastRefill)
+			tokensToAdd := float64(elapsed) / float64(rate)
+
+			tokens += tokensToAdd
+			if tokens > float64(burst) {
+				tokens = float64(burst)
+			}
+			lastRefill = now
+
+			if tokens >= 1.0 {
+				tokens -= 1.0
+				mu.Unlock()
+				return next(input)
+			}
+
+			mu.Unlock()
+			return nil, ErrRateLimitExceeded
+		}
+	}
+}
+
+// Metrics holds performance and execution metrics for a node process.
+type Metrics struct {
+	TotalInvocations      int64
+	SuccessfulInvocations int64
+	FailedInvocations     int64
+	TotalProcessingTime   int64 // Stored in nanoseconds
+}
+
+// MetricsMiddleware tracks invocations, successes, failures, and execution times.
+// Note: It's recommended to pass a pointer to a struct that caller maintains
+func MetricsMiddleware(m *Metrics) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			atomic.AddInt64(&m.TotalInvocations, 1)
+			start := time.Now()
+
+			output, err := next(input)
+
+			duration := time.Since(start).Nanoseconds()
+			atomic.AddInt64(&m.TotalProcessingTime, duration)
+
+			if err != nil {
+				atomic.AddInt64(&m.FailedInvocations, 1)
+			} else {
+				atomic.AddInt64(&m.SuccessfulInvocations, 1)
 			}
 
 			return output, err

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -2,9 +2,10 @@ package node_test
 
 import (
 	"errors"
-	"github.com/lhemerly/Constellation/node"
 	"testing"
 	"time"
+
+	"github.com/lhemerly/Constellation/node"
 )
 
 func TestMiddlewares_Logging(t *testing.T) {
@@ -312,5 +313,94 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 	_, err = n.Process([]byte{})
 	if !errors.Is(err, node.ErrCircuitBreakerOpen) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
+	}
+}
+
+func TestMiddlewares_RateLimit(t *testing.T) {
+	n := node.NewBaseNode("ratelimit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	n.Use(node.RateLimitMiddleware(50*time.Millisecond, 2)) // 2 tokens max, refill 1 every 50ms
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	// 1. Should succeed twice (using initial burst)
+	res1, err1 := n.Process([]byte("input1"))
+	if err1 != nil {
+		t.Fatalf("expected success, got %v", err1)
+	}
+	if string(res1) != "success" {
+		t.Errorf("expected success, got %s", string(res1))
+	}
+
+	res2, err2 := n.Process([]byte("input2"))
+	if err2 != nil {
+		t.Fatalf("expected success, got %v", err2)
+	}
+	if string(res2) != "success" {
+		t.Errorf("expected success, got %s", string(res2))
+	}
+
+	// 2. Should fail immediately since tokens are exhausted
+	_, err3 := n.Process([]byte("input3"))
+	if !errors.Is(err3, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err3)
+	}
+
+	// 3. Wait for refill and try again
+	time.Sleep(60 * time.Millisecond) // Wait for 1 token to refill
+
+	res4, err4 := n.Process([]byte("input4"))
+	if err4 != nil {
+		t.Fatalf("expected success after refill, got %v", err4)
+	}
+	if string(res4) != "success" {
+		t.Errorf("expected success, got %s", string(res4))
+	}
+}
+
+func TestMiddlewares_Metrics(t *testing.T) {
+	n := node.NewBaseNode("metrics-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	metrics := &node.Metrics{}
+	n.Use(node.MetricsMiddleware(metrics))
+
+	failProcess := false
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(10 * time.Millisecond) // Simulate work
+		if failProcess {
+			return nil, errors.New("simulated failure")
+		}
+		return []byte("success"), nil
+	})
+
+	// Process successfully
+	_, err := n.Process([]byte("success"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Process with failure
+	failProcess = true
+	_, err = n.Process([]byte("fail"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	// Verify metrics
+	if metrics.TotalInvocations != 2 {
+		t.Errorf("expected 2 TotalInvocations, got %d", metrics.TotalInvocations)
+	}
+	if metrics.SuccessfulInvocations != 1 {
+		t.Errorf("expected 1 SuccessfulInvocations, got %d", metrics.SuccessfulInvocations)
+	}
+	if metrics.FailedInvocations != 1 {
+		t.Errorf("expected 1 FailedInvocations, got %d", metrics.FailedInvocations)
+	}
+	if metrics.TotalProcessingTime < 20*time.Millisecond.Nanoseconds() { // Total time > 20ms
+		t.Errorf("expected TotalProcessingTime to be > 20ms, got %d ns", metrics.TotalProcessingTime)
 	}
 }


### PR DESCRIPTION
This PR introduces two new powerful middlewares to the `node` package:

1. **RateLimitMiddleware**: Implements a robust, thread-safe token bucket algorithm to rate-limit incoming node processing requests. It avoids spawning background tickers, preventing potential resource leaks, and instead calculates token accumulation lazily based on elapsed time.

2. **MetricsMiddleware**: Provides a way to seamlessly track execution metrics (total invocations, successes, failures, and total nanosecond duration) across node processing chains. It utilizes `sync/atomic` to ensure high performance and safety under highly concurrent workloads.

Both middlewares come with comprehensive unit tests validating their behaviors and error handling.

---
*PR created automatically by Jules for task [9820915386155372920](https://jules.google.com/task/9820915386155372920) started by @lhemerly*