### PR TITLE
docs: fix gRPC connection example in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,10 @@ import (
     "context"
     "fmt"
     "log"
+
     "github.com/lhemerly/Constellation/connection"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -155,7 +158,7 @@ func main() {
     ctx := context.Background()
 
     // Create a new gRPC connection
-    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to create connection: %v", err)
     }


### PR DESCRIPTION
- Fixes the gRPC connection example in `readme.md` to use insecure transport credentials to avoid connection failures due to missing security configuration.
- Added necessary grpc and insecure credential imports to the snippet.

---
*PR created automatically by Jules for task [5474172996802263523](https://jules.google.com/task/5474172996802263523) started by @lhemerly*