### PR TITLE
✨ Feature: Add ScatterGatherNode and resilience middlewares

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -207,6 +208,113 @@ func CircuitBreakerMiddleware(maxFailures int, cooldown time.Duration) Middlewar
 			} else {
 				failures = 0
 				state = 0 // Closed
+			}
+
+			return output, err
+		}
+	}
+}
+
+// ErrRateLimitExceeded is returned when the rate limit is exceeded.
+var ErrRateLimitExceeded = errors.New("rate limit exceeded")
+
+// RateLimitMiddleware restricts how many requests a node can process over a time window.
+// It uses a simple token bucket algorithm without background goroutines to prevent resource leaks.
+func RateLimitMiddleware(capacity int, refillRate time.Duration) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     = capacity
+		lastRefill = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+			now := time.Now()
+			elapsed := now.Sub(lastRefill)
+
+			// Calculate how many tokens to add based on elapsed time
+			if elapsed >= refillRate {
+				tokensToAdd := int(elapsed / refillRate)
+				tokens += tokensToAdd
+				if tokens > capacity {
+					tokens = capacity
+				}
+				lastRefill = now.Add(-time.Duration(elapsed.Nanoseconds() % refillRate.Nanoseconds()))
+			}
+
+			if tokens <= 0 {
+				mu.Unlock()
+				return nil, ErrRateLimitExceeded
+			}
+
+			tokens--
+			mu.Unlock()
+
+			return next(input)
+		}
+	}
+}
+
+// ErrConcurrencyLimitExceeded is returned when the concurrency limit is reached.
+var ErrConcurrencyLimitExceeded = errors.New("concurrency limit exceeded")
+
+// ConcurrencyLimitMiddleware limits the maximum number of concurrent requests a node can handle.
+func ConcurrencyLimitMiddleware(maxConcurrent int) Middleware {
+	sem := make(chan struct{}, maxConcurrent)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			select {
+			case sem <- struct{}{}:
+				// Acquired semaphore
+				defer func() { <-sem }()
+				return next(input)
+			default:
+				// Semaphore full
+				return nil, ErrConcurrencyLimitExceeded
+			}
+		}
+	}
+}
+
+// FallbackMiddleware intercepts errors and calls a user-provided fallback function.
+func FallbackMiddleware(fallback func([]byte, error) ([]byte, error)) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			output, err := next(input)
+			if err != nil {
+				return fallback(input, err)
+			}
+			return output, nil
+		}
+	}
+}
+
+// Metrics tracks the performance and usage statistics of a node.
+type Metrics struct {
+	TotalRequests       uint64
+	SuccessfulRequests  uint64
+	FailedRequests      uint64
+	TotalProcessingTime int64 // stored in nanoseconds
+}
+
+// MetricsMiddleware tracks total requests, successes, failures, and total processing time.
+func MetricsMiddleware(metrics *Metrics) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			atomic.AddUint64(&metrics.TotalRequests, 1)
+
+			start := time.Now()
+			output, err := next(input)
+			duration := time.Since(start).Nanoseconds()
+
+			atomic.AddInt64(&metrics.TotalProcessingTime, duration)
+
+			if err != nil {
+				atomic.AddUint64(&metrics.FailedRequests, 1)
+			} else {
+				atomic.AddUint64(&metrics.SuccessfulRequests, 1)
 			}
 
 			return output, err

--- a/node/scatter_gather_node.go
+++ b/node/scatter_gather_node.go
@@ -1,0 +1,105 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ErrScatterGatherTimeout is returned when the scatter-gather operation times out.
+var ErrScatterGatherTimeout = errors.New("scatter-gather operation timed out")
+
+// ScatterGatherNode broadcasts an input to multiple nodes concurrently,
+// waits for their responses up to a specified timeout, and aggregates the results.
+type ScatterGatherNode struct {
+	*BaseNode
+	nodes   []Node
+	timeout time.Duration
+	gather  func([][]byte) ([]byte, error)
+}
+
+// NewScatterGatherNode creates a new ScatterGatherNode.
+func NewScatterGatherNode(id string, nodes []Node, timeout time.Duration) *ScatterGatherNode {
+	sg := &ScatterGatherNode{
+		BaseNode: NewBaseNode(id),
+		nodes:    nodes,
+		timeout:  timeout,
+		gather:   defaultGather,
+	}
+	sg.SetProcessFunc(sg.scatterGatherProcess)
+	return sg
+}
+
+// SetGatherFunc allows customizing the aggregation of the responses.
+func (sg *ScatterGatherNode) SetGatherFunc(f func([][]byte) ([]byte, error)) {
+	sg.gather = f
+}
+
+func (sg *ScatterGatherNode) scatterGatherProcess(input []byte) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), sg.timeout)
+	defer cancel()
+
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		results [][]byte
+		errs    []error
+	)
+
+	for _, n := range sg.nodes {
+		wg.Add(1)
+		go func(node Node) {
+			defer wg.Done()
+
+			// Clone input to prevent data races
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			resChan := make(chan struct {
+				res []byte
+				err error
+			}, 1)
+
+			go func() {
+				res, err := node.Process(inputCopy)
+				resChan <- struct {
+					res []byte
+					err error
+				}{res, err}
+			}()
+
+			select {
+			case <-ctx.Done():
+				mu.Lock()
+				errs = append(errs, ErrScatterGatherTimeout)
+				mu.Unlock()
+			case r := <-resChan:
+				mu.Lock()
+				if r.err != nil {
+					errs = append(errs, r.err)
+				} else {
+					results = append(results, r.res)
+				}
+				mu.Unlock()
+			}
+		}(n)
+	}
+
+	wg.Wait()
+
+	if len(errs) > 0 {
+		return nil, errors.Join(append([]error{errors.New("scatter-gather failed")}, errs...)...)
+	}
+
+	return sg.gather(results)
+}
+
+// defaultGather concatenates the byte slices.
+func defaultGather(results [][]byte) ([]byte, error) {
+	var aggregated []byte
+	for _, res := range results {
+		aggregated = append(aggregated, res...)
+	}
+	return aggregated, nil
+}

--- a/node/tests/new_middlewares_test.go
+++ b/node/tests/new_middlewares_test.go
@@ -1,0 +1,144 @@
+package node_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestRateLimitMiddleware(t *testing.T) {
+	// Capacity 2, refills every 50ms
+	rateLimiter := node.RateLimitMiddleware(2, 50*time.Millisecond)
+
+	processCount := 0
+	dummyFunc := func(input []byte) ([]byte, error) {
+		processCount++
+		return input, nil
+	}
+
+	wrapped := rateLimiter(dummyFunc)
+
+	// First two should succeed
+	_, err := wrapped([]byte("data"))
+	if err != nil {
+		t.Fatalf("Expected success, got: %v", err)
+	}
+	_, err = wrapped([]byte("data"))
+	if err != nil {
+		t.Fatalf("Expected success, got: %v", err)
+	}
+
+	// Third should fail
+	_, err = wrapped([]byte("data"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("Expected ErrRateLimitExceeded, got: %v", err)
+	}
+
+	// Wait for refill
+	time.Sleep(60 * time.Millisecond)
+
+	// Should succeed again
+	_, err = wrapped([]byte("data"))
+	if err != nil {
+		t.Fatalf("Expected success after refill, got: %v", err)
+	}
+}
+
+func TestConcurrencyLimitMiddleware(t *testing.T) {
+	concurrencyLimiter := node.ConcurrencyLimitMiddleware(2)
+
+	var wg sync.WaitGroup
+	blockCh := make(chan struct{})
+
+	dummyFunc := func(input []byte) ([]byte, error) {
+		<-blockCh
+		return input, nil
+	}
+
+	wrapped := concurrencyLimiter(dummyFunc)
+
+	// Start two concurrent requests that will block
+	wg.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+			_, _ = wrapped([]byte("data"))
+		}()
+	}
+
+	// Wait a tiny bit to ensure they started and acquired the semaphore
+	time.Sleep(10 * time.Millisecond)
+
+	// The third one should fail immediately
+	_, err := wrapped([]byte("data"))
+	if !errors.Is(err, node.ErrConcurrencyLimitExceeded) {
+		t.Fatalf("Expected ErrConcurrencyLimitExceeded, got: %v", err)
+	}
+
+	// Unblock
+	close(blockCh)
+	wg.Wait()
+}
+
+func TestFallbackMiddleware(t *testing.T) {
+	simulatedErr := errors.New("simulated failure")
+
+	fallbackFunc := func(input []byte, err error) ([]byte, error) {
+		if !errors.Is(err, simulatedErr) {
+			t.Errorf("Expected simulatedErr in fallback, got: %v", err)
+		}
+		return []byte("fallback-data"), nil
+	}
+
+	fallbackMiddleware := node.FallbackMiddleware(fallbackFunc)
+
+	dummyFunc := func(input []byte) ([]byte, error) {
+		return nil, simulatedErr
+	}
+
+	wrapped := fallbackMiddleware(dummyFunc)
+
+	output, err := wrapped([]byte("data"))
+	if err != nil {
+		t.Fatalf("Expected no error from fallback, got: %v", err)
+	}
+
+	if string(output) != "fallback-data" {
+		t.Errorf("Expected fallback-data, got: %s", string(output))
+	}
+}
+
+func TestMetricsMiddleware(t *testing.T) {
+	metrics := &node.Metrics{}
+	metricsMiddleware := node.MetricsMiddleware(metrics)
+
+	dummyFunc := func(input []byte) ([]byte, error) {
+		time.Sleep(10 * time.Millisecond)
+		if string(input) == "fail" {
+			return nil, errors.New("simulated error")
+		}
+		return input, nil
+	}
+
+	wrapped := metricsMiddleware(dummyFunc)
+
+	_, _ = wrapped([]byte("success1"))
+	_, _ = wrapped([]byte("success2"))
+	_, _ = wrapped([]byte("fail"))
+
+	if metrics.TotalRequests != 3 {
+		t.Errorf("Expected 3 TotalRequests, got: %d", metrics.TotalRequests)
+	}
+	if metrics.SuccessfulRequests != 2 {
+		t.Errorf("Expected 2 SuccessfulRequests, got: %d", metrics.SuccessfulRequests)
+	}
+	if metrics.FailedRequests != 1 {
+		t.Errorf("Expected 1 FailedRequests, got: %d", metrics.FailedRequests)
+	}
+	if metrics.TotalProcessingTime < int64(30*time.Millisecond) {
+		t.Errorf("Expected TotalProcessingTime > 30ms, got: %d ns", metrics.TotalProcessingTime)
+	}
+}

--- a/node/tests/scatter_gather_node_test.go
+++ b/node/tests/scatter_gather_node_test.go
@@ -1,0 +1,105 @@
+package node_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestScatterGatherNode_Success(t *testing.T) {
+	node1 := node.NewBaseNode("node1")
+	node1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append(input, []byte("-1")...), nil
+	})
+
+	node2 := node.NewBaseNode("node2")
+	node2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append(input, []byte("-2")...), nil
+	})
+
+	sgNode := node.NewScatterGatherNode("sg", []node.Node{node1, node2}, 500*time.Millisecond)
+
+	input := []byte("data")
+	output, err := sgNode.Process(input)
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	outStr := string(output)
+	// Because of concurrency, order of appending isn't strictly guaranteed,
+	// but it should contain both.
+	if !strings.Contains(outStr, "data-1") || !strings.Contains(outStr, "data-2") {
+		t.Errorf("Expected output to contain responses from both nodes, got: %s", outStr)
+	}
+}
+
+func TestScatterGatherNode_Timeout(t *testing.T) {
+	node1 := node.NewBaseNode("node1")
+	node1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(200 * time.Millisecond)
+		return []byte("success"), nil
+	})
+
+	sgNode := node.NewScatterGatherNode("sg", []node.Node{node1}, 50*time.Millisecond)
+
+	_, err := sgNode.Process([]byte("data"))
+	if err == nil {
+		t.Fatal("Expected error due to timeout, got nil")
+	}
+
+	if !errors.Is(err, node.ErrScatterGatherTimeout) {
+		t.Errorf("Expected ErrScatterGatherTimeout, got: %v", err)
+	}
+}
+
+func TestScatterGatherNode_PartialFailure(t *testing.T) {
+	node1 := node.NewBaseNode("node1")
+	node1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	node2 := node.NewBaseNode("node2")
+	node2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("simulated error")
+	})
+
+	sgNode := node.NewScatterGatherNode("sg", []node.Node{node1, node2}, 500*time.Millisecond)
+
+	_, err := sgNode.Process([]byte("data"))
+	if err == nil {
+		t.Fatal("Expected error due to partial failure, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "simulated error") {
+		t.Errorf("Expected error to contain 'simulated error', got: %v", err)
+	}
+}
+
+func TestScatterGatherNode_CustomGather(t *testing.T) {
+	node1 := node.NewBaseNode("node1")
+	node1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("A"), nil
+	})
+
+	node2 := node.NewBaseNode("node2")
+	node2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("B"), nil
+	})
+
+	sgNode := node.NewScatterGatherNode("sg", []node.Node{node1, node2}, 500*time.Millisecond)
+	sgNode.SetGatherFunc(func(results [][]byte) ([]byte, error) {
+		return []byte("custom-aggregation"), nil
+	})
+
+	output, err := sgNode.Process([]byte("data"))
+	if err != nil {
+		t.Fatalf("Expected no error, got: %v", err)
+	}
+
+	if string(output) != "custom-aggregation" {
+		t.Errorf("Expected 'custom-aggregation', got: %s", string(output))
+	}
+}


### PR DESCRIPTION
Implemented a `ScatterGatherNode` for concurrent fan-out and fan-in data processing with context timeouts. Introduced four new middlewares: `RateLimitMiddleware` (token bucket), `ConcurrencyLimitMiddleware` (semaphore-based), `FallbackMiddleware` (error interception), and `MetricsMiddleware` (atomic counter tracking). Added comprehensive unit tests for all new functionalities.

---
*PR created automatically by Jules for task [8201611631925078529](https://jules.google.com/task/8201611631925078529) started by @lhemerly*