### PR TITLE
docs: update gRPC usage example with transport credentials

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,10 @@ import (
     "context"
     "fmt"
     "log"
+
     "github.com/lhemerly/Constellation/connection"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -155,7 +158,7 @@ func main() {
     ctx := context.Background()
 
     // Create a new gRPC connection
-    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to create connection: %v", err)
     }


### PR DESCRIPTION
Fixes the missing transport credentials in the gRPC usage example within the README, which would fail when running with newer versions of `google.golang.org/grpc`.

---
*PR created automatically by Jules for task [14628484558912791692](https://jules.google.com/task/14628484558912791692) started by @lhemerly*