### PR TITLE
feat: Add ScatterGatherNode, RateLimit, and Metrics Middlewares

### DIFF
--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -6,12 +6,14 @@ import (
 	"errors"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 var (
 	ErrCircuitBreakerOpen = errors.New("circuit breaker is open")
 	ErrProcessTimeout     = errors.New("process timed out")
+	ErrRateLimitExceeded  = errors.New("rate limit exceeded")
 )
 
 // LoggingMiddleware logs the payload size and processing time.
@@ -57,6 +59,69 @@ func RetryMiddleware(retries int, delay time.Duration) Middleware {
 			}
 
 			return nil, errors.Join(errors.New("operation failed after retries"), err)
+		}
+	}
+}
+
+// RateLimitMiddleware limits the number of requests that can be processed per second using a token bucket algorithm.
+func RateLimitMiddleware(requestsPerSecond float64, burstSize int) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64   = float64(burstSize)
+		lastUpdate time.Time = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+			now := time.Now()
+			elapsed := now.Sub(lastUpdate).Seconds()
+
+			tokens += elapsed * requestsPerSecond
+			if tokens > float64(burstSize) {
+				tokens = float64(burstSize)
+			}
+			lastUpdate = now
+
+			if tokens >= 1.0 {
+				tokens -= 1.0
+				mu.Unlock()
+				return next(input)
+			}
+
+			mu.Unlock()
+			return nil, ErrRateLimitExceeded
+		}
+	}
+}
+
+// NodeMetrics holds statistics about the processed requests.
+type NodeMetrics struct {
+	TotalRequests      uint64
+	SuccessfulRequests uint64
+	FailedRequests     uint64
+	TotalDurationNs    uint64 // Total duration in nanoseconds
+}
+
+// MetricsMiddleware tracks total requests, successes, failures, and processing durations.
+func MetricsMiddleware(metrics *NodeMetrics) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			atomic.AddUint64(&metrics.TotalRequests, 1)
+			start := time.Now()
+
+			output, err := next(input)
+
+			duration := time.Since(start).Nanoseconds()
+			atomic.AddUint64(&metrics.TotalDurationNs, uint64(duration))
+
+			if err != nil {
+				atomic.AddUint64(&metrics.FailedRequests, 1)
+			} else {
+				atomic.AddUint64(&metrics.SuccessfulRequests, 1)
+			}
+
+			return output, err
 		}
 	}
 }

--- a/node/scatter_gather_node.go
+++ b/node/scatter_gather_node.go
@@ -1,0 +1,161 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ScatterGatherNode broadcasts an input to multiple nodes concurrently
+// and gathers their results. It can optionally enforce a timeout.
+type ScatterGatherNode struct {
+	*BaseNode
+	targets []Node
+	timeout time.Duration
+}
+
+// NewScatterGatherNode creates a new ScatterGatherNode.
+// If timeout is > 0, the node will wait up to that duration for all results.
+func NewScatterGatherNode(id string, targets []Node, timeout time.Duration) *ScatterGatherNode {
+	if len(targets) == 0 {
+		panic("ScatterGatherNode requires at least one target node")
+	}
+
+	sgNode := &ScatterGatherNode{
+		BaseNode: NewBaseNode(id),
+		targets:  targets,
+		timeout:  timeout,
+	}
+
+	sgNode.SetProcessFunc(sgNode.scatterGatherProcess)
+
+	return sgNode
+}
+
+// scatterGatherProcess handles the broadcast and aggregation of results.
+func (sg *ScatterGatherNode) scatterGatherProcess(input []byte) ([]byte, error) {
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		errs    []error
+		results [][]byte
+	)
+
+	// Context for optional timeout
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if sg.timeout > 0 {
+		ctx, cancel = context.WithTimeout(context.Background(), sg.timeout)
+		defer cancel()
+	}
+
+	doneChan := make(chan struct{})
+
+	// Scatter phase
+	for _, target := range sg.targets {
+		wg.Add(1)
+		go func(n Node) {
+			defer wg.Done()
+
+			// Fast-fail if context is already done
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+
+			// Clone input to prevent data races
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			resChan := make(chan struct {
+				res []byte
+				err error
+			}, 1)
+
+			go func() {
+				r, e := n.Process(inputCopy)
+				resChan <- struct {
+					res []byte
+					err error
+				}{r, e}
+			}()
+
+			select {
+			case r := <-resChan:
+				mu.Lock()
+				if r.err != nil {
+					errs = append(errs, r.err)
+				} else {
+					results = append(results, r.res)
+				}
+				mu.Unlock()
+			case <-ctx.Done():
+				// Context cancelled or timed out
+				mu.Lock()
+				errs = append(errs, ctx.Err())
+				mu.Unlock()
+			}
+
+		}(target)
+	}
+
+	go func() {
+		wg.Wait()
+		close(doneChan)
+	}()
+
+	// Wait for completion or fast-fail entirely if all workers complete
+	select {
+	case <-doneChan:
+		// All completed
+	case <-ctx.Done():
+		// Wait for remaining workers to acknowledge cancellation
+		<-doneChan
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.Join(append([]error{errors.New("scatter-gather failed")}, errs...)...)
+	}
+
+	// Gather phase: simple concatenation for this basic implementation.
+	var gatheredInput []byte
+	for _, res := range results {
+		gatheredInput = append(gatheredInput, res...)
+	}
+
+	return gatheredInput, nil
+}
+
+// Create initializes the scatter-gather node and its dependencies.
+func (sg *ScatterGatherNode) Create() error {
+	if err := sg.BaseNode.Create(); err != nil {
+		return err
+	}
+	for _, t := range sg.targets {
+		if err := t.Create(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Delete cleans up the scatter-gather node and its dependencies.
+func (sg *ScatterGatherNode) Delete() error {
+	var errs []error
+	if err := sg.BaseNode.Delete(); err != nil {
+		errs = append(errs, err)
+	}
+	for _, t := range sg.targets {
+		if err := t.Delete(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -314,3 +314,81 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
 	}
 }
+
+func TestMiddlewares_RateLimit(t *testing.T) {
+	n := node.NewBaseNode("rate-limit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// 10 requests per second, burst of 2
+	n.Use(node.RateLimitMiddleware(10.0, 2))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("success"), nil
+	})
+
+	// First two requests should succeed (burst)
+	for i := 0; i < 2; i++ {
+		_, err := n.Process([]byte("input"))
+		if err != nil {
+			t.Fatalf("expected nil error on request %d, got %v", i+1, err)
+		}
+	}
+
+	// Third request should fail immediately
+	_, err := n.Process([]byte("input"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// Wait enough time to accumulate 1 token (10 requests/sec = 100ms per token)
+	time.Sleep(110 * time.Millisecond)
+
+	// Next request should succeed
+	_, err = n.Process([]byte("input"))
+	if err != nil {
+		t.Fatalf("expected nil error after waiting, got %v", err)
+	}
+}
+
+func TestMiddlewares_Metrics(t *testing.T) {
+	n := node.NewBaseNode("metrics-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	metrics := &node.NodeMetrics{}
+	n.Use(node.MetricsMiddleware(metrics))
+
+	var fail bool
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(10 * time.Millisecond) // Simulate some work
+		if fail {
+			return nil, errors.New("simulated error")
+		}
+		return []byte("success"), nil
+	})
+
+	// Successful request
+	_, err := n.Process([]byte("input1"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Failed request
+	fail = true
+	_, err = n.Process([]byte("input2"))
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if metrics.TotalRequests != 2 {
+		t.Errorf("expected 2 total requests, got %d", metrics.TotalRequests)
+	}
+	if metrics.SuccessfulRequests != 1 {
+		t.Errorf("expected 1 successful request, got %d", metrics.SuccessfulRequests)
+	}
+	if metrics.FailedRequests != 1 {
+		t.Errorf("expected 1 failed request, got %d", metrics.FailedRequests)
+	}
+	if metrics.TotalDurationNs == 0 {
+		t.Errorf("expected non-zero total duration")
+	}
+}

--- a/node/tests/scatter_gather_test.go
+++ b/node/tests/scatter_gather_test.go
@@ -1,0 +1,111 @@
+package node_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestScatterGatherNode_Success(t *testing.T) {
+	target1 := node.NewBaseNode("target1")
+	target1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("T1:"), input...), nil
+	})
+
+	target2 := node.NewBaseNode("target2")
+	target2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("T2:"), input...), nil
+	})
+
+	targets := []node.Node{target1, target2}
+	sg := node.NewScatterGatherNode("sg", targets, 0)
+	defer cleanupNodes(t, append(targets, sg))
+
+	if err := sg.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	res, err := sg.Process([]byte("data"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resStr := string(res)
+	if !strings.Contains(resStr, "T1:data") || !strings.Contains(resStr, "T2:data") {
+		t.Errorf("unexpected result: %s", resStr)
+	}
+}
+
+func TestScatterGatherNode_PartialFailure(t *testing.T) {
+	target1 := node.NewBaseNode("target1")
+	target1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("T1:"), input...), nil
+	})
+
+	target2 := node.NewBaseNode("target2")
+	expectedErr := errors.New("target2 failed")
+	target2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, expectedErr
+	})
+
+	targets := []node.Node{target1, target2}
+	sg := node.NewScatterGatherNode("sg", targets, 0)
+	defer cleanupNodes(t, append(targets, sg))
+
+	if err := sg.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	_, err := sg.Process([]byte("data"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "scatter-gather failed") || !strings.Contains(err.Error(), "target2 failed") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestScatterGatherNode_Timeout(t *testing.T) {
+	target1 := node.NewBaseNode("target1")
+	target1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("T1:done"), nil
+	})
+
+	target2 := node.NewBaseNode("target2")
+	target2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(100 * time.Millisecond) // slow process
+		return []byte("T2:done"), nil
+	})
+
+	targets := []node.Node{target1, target2}
+	// 50ms timeout
+	sg := node.NewScatterGatherNode("sg", targets, 50*time.Millisecond)
+	defer cleanupNodes(t, append(targets, sg))
+
+	if err := sg.Create(); err != nil {
+		t.Fatalf("failed to create node: %v", err)
+	}
+
+	_, err := sg.Process([]byte("data"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Errorf("expected timeout error, got %v", err)
+	}
+}
+
+func TestScatterGatherNode_PanicOnEmptyTargets(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic on empty targets")
+		}
+	}()
+	node.NewScatterGatherNode("sg", []node.Node{}, 0)
+}

--- a/readme.md
+++ b/readme.md
@@ -25,8 +25,8 @@ The `node` package provides abstractions for creating and managing nodes within 
 - Data Processing
 - Subscription Management
 - Event Notification
-- **Advanced Node Types**: Includes `FailoverNode` (primary/secondary logic), `LoadBalancerNode` (round-robin distribution), `PipelineNode` (sequential stage processing), `RouterNode` (conditional message routing), and `MapReduceNode` (parallel mappers and a single reducer).
-- **Middlewares**: Supports composing node processing chains with middlewares such as `LoggingMiddleware`, `RetryMiddleware`, `RecoveryMiddleware`, `CacheMiddleware`, `TimeoutMiddleware`, and `CircuitBreakerMiddleware`.
+- **Advanced Node Types**: Includes `FailoverNode` (primary/secondary logic), `LoadBalancerNode` (round-robin distribution), `PipelineNode` (sequential stage processing), `RouterNode` (conditional message routing), `MapReduceNode` (parallel mappers and a single reducer), and `ScatterGatherNode` (broadcast to targets and aggregate results, with optional timeout).
+- **Middlewares**: Supports composing node processing chains with middlewares such as `LoggingMiddleware`, `RetryMiddleware`, `RecoveryMiddleware`, `CacheMiddleware`, `TimeoutMiddleware`, `CircuitBreakerMiddleware`, `RateLimitMiddleware` (token bucket limiting), and `MetricsMiddleware` (tracking requests and performance).
 
 ### 2. Connection Package
 


### PR DESCRIPTION
I've explored the codebase and implemented several creative new features to enhance the framework's capabilities:

1. **`ScatterGatherNode`:** I noticed the framework supports fan-out operations (like `Notify` or `MapReduce`) but lacked a node specifically designed to scatter a single request to multiple targets, wait for their responses, and aggregate them back together with timeout controls. I implemented a robust `ScatterGatherNode` using sophisticated goroutine synchronization to support fast-failing and safe context cancellations.
2. **`RateLimitMiddleware`:** To improve resilience, I added a token-bucket rate limiter. I specifically avoided using background ticker goroutines to prevent resource leaks and instead built it using `time.Now()` elapsed delta calculations and `sync.Mutex` for peak efficiency.
3. **`MetricsMiddleware`:** Observability is crucial, so I implemented a middleware that captures execution counts, success/failure rates, and total duration using `sync/atomic` to avoid any lock contention overhead on the hot path.

All features are fully tested, documented in the `readme.md`, and passed code review.

---
*PR created automatically by Jules for task [12195944423432090448](https://jules.google.com/task/12195944423432090448) started by @lhemerly*