### PR TITLE
docs: fix gRPC code example in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,8 @@ import (
     "context"
     "fmt"
     "log"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
     "github.com/lhemerly/Constellation/connection"
 )
 
@@ -155,7 +157,7 @@ func main() {
     ctx := context.Background()
 
     // Create a new gRPC connection
-    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to create connection: %v", err)
     }


### PR DESCRIPTION
This PR updates the `readme.md` connection package example for gRPC to include explicit transport credentials, satisfying newer `google.golang.org/grpc` library requirements for non-TLS connections. Added necessary imports to the code snippet as well.
The entire codebase was audited and confirmed to include all functionality documented in the README.

---
*PR created automatically by Jules for task [12407852775039152651](https://jules.google.com/task/12407852775039152651) started by @lhemerly*