### PR TITLE
Add RateLimiter and Metrics node middlewares

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -17,3 +17,11 @@
 ## 2024-05-18 - Optimize Lock Contention in Notify Method
 **Learning:** Holding a read lock (`RLock()`) for the entire duration of iterating over a map and spawning long-running or blocking goroutines (`wg.Wait()`) creates massive lock contention and opens the door for deadlocks. If any of the spawned workers attempt to acquire a write lock (`Lock()`) on the same mutex (e.g., trying to subscribe or unsubscribe), it will deadlock because the read lock is still held by the waiting parent.
 **Action:** Always copy map/slice contents to a local slice under the lock, then immediately release the lock before iterating and processing the items concurrently. Apply this specifically when dealing with publisher/subscriber patterns in the codebase to keep the hot path lock-free.
+
+## 2024-06-25 - Atomic Operations for Metrics Tracking
+**Learning:** When building node middleware to track invocation metrics in a highly concurrent framework like Constellation, using standard `uint64` counters will result in data races.
+**Action:** Use `sync/atomic` methods like `atomic.AddUint64` and `atomic.AddInt64` for tracking counters (invocations, successes, failures, total duration) to safely gather stats across concurrent node processing routines.
+
+## 2024-06-25 - Rate Limiting with Mutex and Token Bucket
+**Learning:** For rate limiting middleware, spawning background `time.Ticker` goroutines to refill tokens can leak resources if not cleaned up properly during node teardown.
+**Action:** Calculate the elapsed time explicitly (`time.Now().Sub(lastRefill)`) on each request within a `sync.Mutex` lock to refill tokens dynamically based on the refill rate. This eliminates the need for background goroutines while maintaining accurate rate limiting.

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -212,4 +213,76 @@ func CircuitBreakerMiddleware(maxFailures int, cooldown time.Duration) Middlewar
 			return output, err
 		}
 	}
+}
+
+var ErrRateLimitExceeded = errors.New("rate limit exceeded")
+
+// RateLimiterMiddleware limits the number of operations per time window.
+func RateLimiterMiddleware(maxTokens float64, refillRate float64) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64   = maxTokens
+		lastRefill time.Time = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+			now := time.Now()
+			elapsed := now.Sub(lastRefill).Seconds()
+
+			// Refill tokens based on elapsed time
+			tokens += elapsed * refillRate
+			if tokens > maxTokens {
+				tokens = maxTokens
+			}
+			lastRefill = now
+
+			// Check if we have enough tokens to proceed
+			if tokens >= 1.0 {
+				tokens -= 1.0
+				mu.Unlock()
+				return next(input)
+			}
+
+			mu.Unlock()
+			return nil, ErrRateLimitExceeded
+		}
+	}
+}
+
+// Metrics holds performance and processing statistics for a node.
+type Metrics struct {
+	Invocations uint64
+	Successes   uint64
+	Failures    uint64
+	TotalTime   int64 // Stored in nanoseconds
+}
+
+// NewMetricsMiddleware creates a middleware that tracks invocations, successes, failures, and execution time.
+// It returns the middleware function and a pointer to the Metrics struct where stats are stored.
+func NewMetricsMiddleware() (Middleware, *Metrics) {
+	metrics := &Metrics{}
+
+	middleware := func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			atomic.AddUint64(&metrics.Invocations, 1)
+
+			start := time.Now()
+			output, err := next(input)
+			duration := time.Since(start)
+
+			atomic.AddInt64(&metrics.TotalTime, duration.Nanoseconds())
+
+			if err != nil {
+				atomic.AddUint64(&metrics.Failures, 1)
+			} else {
+				atomic.AddUint64(&metrics.Successes, 1)
+			}
+
+			return output, err
+		}
+	}
+
+	return middleware, metrics
 }

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -314,3 +314,86 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
 	}
 }
+
+func TestMiddlewares_RateLimiter(t *testing.T) {
+	n := node.NewBaseNode("ratelimit-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	// 2 tokens max, 10 tokens refilled per second
+	n.Use(node.RateLimiterMiddleware(2, 10))
+
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("ok"), nil
+	})
+
+	// 1st request should pass
+	_, err := n.Process([]byte("req1"))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	// 2nd request should pass
+	_, err = n.Process([]byte("req2"))
+	if err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+
+	// 3rd request should fail immediately since tokens are depleted and not enough time elapsed
+	_, err = n.Process([]byte("req3"))
+	if !errors.Is(err, node.ErrRateLimitExceeded) {
+		t.Fatalf("expected ErrRateLimitExceeded, got %v", err)
+	}
+
+	// Wait enough time to get 1 token back (10 tokens/sec = 1 token/100ms)
+	time.Sleep(150 * time.Millisecond)
+
+	// Should pass again
+	_, err = n.Process([]byte("req4"))
+	if err != nil {
+		t.Fatalf("expected nil error after waiting, got %v", err)
+	}
+}
+
+func TestMiddlewares_Metrics(t *testing.T) {
+	n := node.NewBaseNode("metrics-node")
+	defer cleanupNodes(t, []node.Node{n})
+
+	metricsMiddleware, metrics := node.NewMetricsMiddleware()
+	n.Use(metricsMiddleware)
+
+	var fail bool
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		if fail {
+			return nil, errors.New("simulated error")
+		}
+		time.Sleep(10 * time.Millisecond)
+		return []byte("ok"), nil
+	})
+
+	// Successful request
+	_, _ = n.Process([]byte("req1"))
+
+	// Failed request
+	fail = true
+	_, _ = n.Process([]byte("req2"))
+
+	// Another successful request
+	fail = false
+	_, _ = n.Process([]byte("req3"))
+
+	if metrics.Invocations != 3 {
+		t.Errorf("expected 3 invocations, got %d", metrics.Invocations)
+	}
+	if metrics.Successes != 2 {
+		t.Errorf("expected 2 successes, got %d", metrics.Successes)
+	}
+	if metrics.Failures != 1 {
+		t.Errorf("expected 1 failure, got %d", metrics.Failures)
+	}
+
+	totalTimeMs := time.Duration(metrics.TotalTime).Milliseconds()
+	// Total sleep time is around 20ms for the two successful ones, let's just make sure it's > 0
+	if totalTimeMs < 10 {
+		t.Errorf("expected total time to be >= 10ms, got %dms", totalTimeMs)
+	}
+}


### PR DESCRIPTION
Introduced RateLimiter and Metrics middleware to Constellation framework's node processing pipeline.

---
*PR created automatically by Jules for task [18192400926715428199](https://jules.google.com/task/18192400926715428199) started by @lhemerly*