### PR TITLE
docs: add missing grpc transport credentials in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -148,6 +148,8 @@ import (
     "fmt"
     "log"
     "github.com/lhemerly/Constellation/connection"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -155,7 +157,7 @@ func main() {
     ctx := context.Background()
 
     // Create a new gRPC connection
-    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to create connection: %v", err)
     }


### PR DESCRIPTION
This PR fixes the gRPC connection example in `readme.md` which failed to compile/run because it lacked explicit transport credentials (required by modern `grpc-go`). I also verified that all functionality mentioned in the README (like node types, middlewares, and events) are actually present in the codebase.

---
*PR created automatically by Jules for task [8153463468292436684](https://jules.google.com/task/8153463468292436684) started by @lhemerly*