### PR TITLE
docs: update readme connection example to include required grpc dial options

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -147,7 +147,10 @@ import (
     "context"
     "fmt"
     "log"
+
     "github.com/lhemerly/Constellation/connection"
+    "google.golang.org/grpc"
+    "google.golang.org/grpc/credentials/insecure"
 )
 
 func main() {
@@ -155,7 +158,7 @@ func main() {
     ctx := context.Background()
 
     // Create a new gRPC connection
-    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051")
+    conn, err := factory.NewConnection(ctx, "grpc", "localhost:50051", grpc.WithTransportCredentials(insecure.NewCredentials()))
     if err != nil {
         log.Fatalf("Failed to create connection: %v", err)
     }


### PR DESCRIPTION
Updated the `Connection Package` example in `readme.md` to pass `grpc.WithTransportCredentials(insecure.NewCredentials())` when creating the gRPC connection, and added the necessary `google.golang.org/grpc` imports. In newer versions of gRPC, creating a connection without explicit transport credentials configured causes failures.

No features mentioned in the README are missing from the codebase. Everything, including Advanced Node Types and Middlewares, is fully implemented.

---
*PR created automatically by Jules for task [6619447148905766004](https://jules.google.com/task/6619447148905766004) started by @lhemerly*