### PR TITLE
feat: add WorkerPoolNode, FanOutNode, and advanced middlewares

### DIFF
--- a/node/fan_out_node.go
+++ b/node/fan_out_node.go
@@ -1,0 +1,145 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// FanOutNode implements concurrent scatter-gather processing.
+// It sends the input to all target nodes simultaneously and collects the results.
+type FanOutNode struct {
+	*BaseNode
+	targets []Node
+	timeout time.Duration
+}
+
+// NewFanOutNode creates a new FanOutNode with the specified targets and timeout.
+func NewFanOutNode(id string, targets []Node, timeout time.Duration) *FanOutNode {
+	if len(targets) == 0 {
+		panic("FanOutNode requires at least one target node")
+	}
+
+	fanOutNode := &FanOutNode{
+		BaseNode: NewBaseNode(id),
+		targets:  targets,
+		timeout:  timeout,
+	}
+
+	fanOutNode.SetProcessFunc(fanOutNode.fanOutProcess)
+	return fanOutNode
+}
+
+func (fo *FanOutNode) fanOutProcess(input []byte) ([]byte, error) {
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var errs []error
+	var results [][]byte
+
+	ctx, cancel := context.WithTimeout(context.Background(), fo.timeout)
+	defer cancel()
+
+	for _, target := range fo.targets {
+		wg.Add(1)
+		go func(n Node) {
+			defer wg.Done()
+
+			// Clone input to prevent data races
+			inputCopy := make([]byte, len(input))
+			copy(inputCopy, input)
+
+			resChan := make(chan struct {
+				res []byte
+				err error
+			}, 1)
+
+			go func() {
+				res, err := n.Process(inputCopy)
+				resChan <- struct {
+					res []byte
+					err error
+				}{res, err}
+			}()
+
+			select {
+			case <-ctx.Done():
+				mu.Lock()
+				errs = append(errs, errors.New("target node timed out"))
+				mu.Unlock()
+			case r := <-resChan:
+				mu.Lock()
+				if r.err != nil {
+					errs = append(errs, r.err)
+				} else {
+					results = append(results, r.res)
+				}
+				mu.Unlock()
+			}
+		}(target)
+	}
+
+	// We must have a dedicated doneChan to wait for the WG.
+	// We cannot just use time.After or blocking Wait() here directly because
+	// we want to return as soon as all workers finish, without waiting for the timeout
+	// if they finish early.
+	doneChan := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(doneChan)
+	}()
+
+	select {
+	case <-doneChan:
+		// All goroutines finished
+	case <-ctx.Done():
+		// Main timeout reached, some might still be running but we don't care
+	}
+
+	// Wait for any remaining cleanup or context cancellation completion in the worker goroutines
+	// to ensure mu is fully updated. doneChan guarantees they are all past the select block.
+	<-doneChan
+
+	if len(errs) == len(fo.targets) {
+		return nil, errors.Join(append([]error{errors.New("all target nodes failed or timed out")}, errs...)...)
+	}
+
+	// Aggregate successful results
+	var aggregatedResult []byte
+	for _, res := range results {
+		aggregatedResult = append(aggregatedResult, res...)
+	}
+
+	return aggregatedResult, nil
+}
+
+// Create initializes the node and its targets.
+func (fo *FanOutNode) Create() error {
+	if err := fo.BaseNode.Create(); err != nil {
+		return err
+	}
+	for _, target := range fo.targets {
+		if err := target.Create(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Delete cleans up the node and its targets.
+func (fo *FanOutNode) Delete() error {
+	var errs []error
+	if err := fo.BaseNode.Delete(); err != nil {
+		errs = append(errs, err)
+	}
+	for _, target := range fo.targets {
+		if err := target.Delete(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}

--- a/node/middlewares.go
+++ b/node/middlewares.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -210,6 +211,73 @@ func CircuitBreakerMiddleware(maxFailures int, cooldown time.Duration) Middlewar
 			}
 
 			return output, err
+		}
+	}
+}
+
+// NodeMetrics holds atomic counters for tracking node execution.
+type NodeMetrics struct {
+	TotalRequests         uint64
+	SuccessfulRequests    uint64
+	FailedRequests        uint64
+	TotalProcessingTimeNs uint64
+}
+
+// MetricsMiddleware tracks total requests, successful requests, failed requests, and total processing duration.
+func MetricsMiddleware(metrics *NodeMetrics) Middleware {
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			atomic.AddUint64(&metrics.TotalRequests, 1)
+			start := time.Now()
+
+			output, err := next(input)
+
+			duration := time.Since(start)
+			atomic.AddUint64(&metrics.TotalProcessingTimeNs, uint64(duration.Nanoseconds()))
+
+			if err != nil {
+				atomic.AddUint64(&metrics.FailedRequests, 1)
+			} else {
+				atomic.AddUint64(&metrics.SuccessfulRequests, 1)
+			}
+
+			return output, err
+		}
+	}
+}
+
+// RateLimiterMiddleware limits the rate of processing using a token bucket algorithm.
+// It avoids background goroutines by calculating elapsed time on each request.
+func RateLimiterMiddleware(rate float64, capacity float64) Middleware {
+	var (
+		mu         sync.Mutex
+		tokens     float64   = capacity
+		lastUpdate time.Time = time.Now()
+	)
+
+	return func(next func([]byte) ([]byte, error)) func([]byte) ([]byte, error) {
+		return func(input []byte) ([]byte, error) {
+			mu.Lock()
+
+			now := time.Now()
+			elapsed := now.Sub(lastUpdate).Seconds()
+
+			// Add tokens based on elapsed time and rate
+			tokens += elapsed * rate
+			if tokens > capacity {
+				tokens = capacity
+			}
+			lastUpdate = now
+
+			if tokens < 1.0 {
+				mu.Unlock()
+				return nil, errors.New("rate limit exceeded")
+			}
+
+			tokens -= 1.0
+			mu.Unlock()
+
+			return next(input)
 		}
 	}
 }

--- a/node/tests/fan_out_node_test.go
+++ b/node/tests/fan_out_node_test.go
@@ -1,0 +1,90 @@
+package node_test
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestFanOutNode_Success(t *testing.T) {
+	n1 := node.NewBaseNode("n1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("1:"), input...), nil
+	})
+
+	n2 := node.NewBaseNode("n2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return append([]byte("2:"), input...), nil
+	})
+
+	fo := node.NewFanOutNode("fo", []node.Node{n1, n2}, 2*time.Second)
+	if err := fo.Create(); err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	defer fo.Delete()
+
+	out, err := fo.Process([]byte("test"))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	outStr := string(out)
+	if !strings.Contains(outStr, "1:test") || !strings.Contains(outStr, "2:test") {
+		t.Fatalf("Unexpected output: %s", outStr)
+	}
+}
+
+func TestFanOutNode_PartialTimeout(t *testing.T) {
+	n1 := node.NewBaseNode("fast")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return []byte("fast-result"), nil
+	})
+
+	n2 := node.NewBaseNode("slow")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		time.Sleep(200 * time.Millisecond)
+		return []byte("slow-result"), nil
+	})
+
+	fo := node.NewFanOutNode("fo-timeout", []node.Node{n1, n2}, 50*time.Millisecond)
+	fo.Create()
+	defer fo.Delete()
+
+	out, err := fo.Process([]byte("test"))
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !bytes.Equal(out, []byte("fast-result")) {
+		t.Fatalf("Expected fast-result, got: %s", string(out))
+	}
+}
+
+func TestFanOutNode_AllFailed(t *testing.T) {
+	n1 := node.NewBaseNode("err1")
+	n1.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("err1")
+	})
+
+	n2 := node.NewBaseNode("err2")
+	n2.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, errors.New("err2")
+	})
+
+	fo := node.NewFanOutNode("fo-err", []node.Node{n1, n2}, 1*time.Second)
+	fo.Create()
+	defer fo.Delete()
+
+	_, err := fo.Process([]byte("test"))
+	if err == nil {
+		t.Fatal("Expected error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "all target nodes failed or timed out") {
+		t.Fatalf("Unexpected error format: %v", err)
+	}
+}

--- a/node/tests/middlewares_test.go
+++ b/node/tests/middlewares_test.go
@@ -2,9 +2,11 @@ package node_test
 
 import (
 	"errors"
-	"github.com/lhemerly/Constellation/node"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/lhemerly/Constellation/node"
 )
 
 func TestMiddlewares_Logging(t *testing.T) {
@@ -312,5 +314,82 @@ func TestMiddlewares_CircuitBreaker_EmptyInput(t *testing.T) {
 	_, err = n.Process([]byte{})
 	if !errors.Is(err, node.ErrCircuitBreakerOpen) {
 		t.Fatalf("expected ErrCircuitBreakerOpen, got %v", err)
+	}
+}
+
+func TestMetricsMiddleware(t *testing.T) {
+	metrics := &node.NodeMetrics{}
+	mw := node.MetricsMiddleware(metrics)
+
+	n := node.NewBaseNode("metrics-node")
+	n.SetProcessFunc(func(input []byte) ([]byte, error) {
+		if len(input) == 0 {
+			return nil, errors.New("empty input")
+		}
+		time.Sleep(10 * time.Millisecond) // Simulate work
+		return input, nil
+	})
+	n.Use(mw)
+
+	// Success case
+	_, err := n.Process([]byte("test"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Failure case
+	_, err = n.Process([]byte{})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+
+	if atomic.LoadUint64(&metrics.TotalRequests) != 2 {
+		t.Errorf("expected 2 total requests, got %d", metrics.TotalRequests)
+	}
+	if atomic.LoadUint64(&metrics.SuccessfulRequests) != 1 {
+		t.Errorf("expected 1 successful request, got %d", metrics.SuccessfulRequests)
+	}
+	if atomic.LoadUint64(&metrics.FailedRequests) != 1 {
+		t.Errorf("expected 1 failed request, got %d", metrics.FailedRequests)
+	}
+	if atomic.LoadUint64(&metrics.TotalProcessingTimeNs) == 0 {
+		t.Errorf("expected TotalProcessingTimeNs to be > 0")
+	}
+}
+
+func TestRateLimiterMiddleware(t *testing.T) {
+	// Rate: 10 tokens/sec, Capacity: 2 tokens
+	mw := node.RateLimiterMiddleware(10.0, 2.0)
+
+	n := node.NewBaseNode("rate-limit-node")
+	n.Use(mw)
+
+	// Should succeed for the first 2 requests (capacity = 2)
+	_, err := n.Process([]byte("req1"))
+	if err != nil {
+		t.Fatalf("unexpected error on req1: %v", err)
+	}
+
+	_, err = n.Process([]byte("req2"))
+	if err != nil {
+		t.Fatalf("unexpected error on req2: %v", err)
+	}
+
+	// Should fail immediately for the 3rd request since bucket is empty
+	_, err = n.Process([]byte("req3"))
+	if err == nil {
+		t.Fatalf("expected rate limit error on req3, got nil")
+	}
+	if err.Error() != "rate limit exceeded" {
+		t.Fatalf("expected rate limit exceeded error, got: %v", err)
+	}
+
+	// Wait enough time to replenish at least 1 token (rate = 10/sec, so 1 token = 100ms)
+	time.Sleep(110 * time.Millisecond)
+
+	// Should succeed now
+	_, err = n.Process([]byte("req4"))
+	if err != nil {
+		t.Fatalf("unexpected error on req4 after waiting: %v", err)
 	}
 }

--- a/node/tests/worker_pool_node_test.go
+++ b/node/tests/worker_pool_node_test.go
@@ -1,0 +1,120 @@
+package node_test
+
+import (
+	"bytes"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/lhemerly/Constellation/node"
+)
+
+func TestWorkerPoolNode_ProcessAndScale(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-1", 5)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("Failed to create worker pool node: %v", err)
+	}
+	defer wp.Delete()
+
+	var counter int32
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		atomic.AddInt32(&counter, 1)
+		time.Sleep(10 * time.Millisecond) // Simulate work
+		return append([]byte("processed: "), input...), nil
+	})
+
+	const numRequests = 20
+	resChan := make(chan struct {
+		out []byte
+		err error
+	}, numRequests)
+
+	// Send requests concurrently
+	for i := 0; i < numRequests; i++ {
+		go func(idx int) {
+			input := []byte{byte(idx)}
+			out, err := wp.Process(input)
+			resChan <- struct {
+				out []byte
+				err error
+			}{out, err}
+		}(i)
+	}
+
+	for i := 0; i < numRequests; i++ {
+		res := <-resChan
+		if res.err != nil {
+			t.Errorf("Unexpected error: %v", res.err)
+		}
+		if !bytes.HasPrefix(res.out, []byte("processed: ")) {
+			t.Errorf("Unexpected output: %s", string(res.out))
+		}
+	}
+
+	if atomic.LoadInt32(&counter) != int32(numRequests) {
+		t.Errorf("Expected %d requests processed, got %d", numRequests, counter)
+	}
+}
+
+func TestWorkerPoolNode_ShutdownDrain(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-shutdown", 2)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+
+	blockCh := make(chan struct{})
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		<-blockCh // block the worker to simulate long task and allow queue to build up
+		return input, nil
+	})
+
+	// Fill the pool and queue
+	for i := 0; i < 4; i++ {
+		go wp.Process([]byte("test"))
+	}
+
+	// Small delay to ensure they are queued/running
+	time.Sleep(50 * time.Millisecond)
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- wp.Delete()
+	}()
+
+	// The delete will block until the workers are done. Let's unblock them.
+	close(blockCh)
+
+	select {
+	case err := <-errChan:
+		if err != nil {
+			t.Errorf("Unexpected error during delete: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Delete timed out, probably blocked on workers")
+	}
+
+	// Ensure new processes are rejected after shutdown
+	_, err := wp.Process([]byte("post-shutdown"))
+	if err == nil {
+		t.Fatal("Expected error processing after shutdown, got nil")
+	}
+}
+
+func TestWorkerPoolNode_WorkerError(t *testing.T) {
+	wp := node.NewWorkerPoolNode("wp-err", 1)
+	if err := wp.Create(); err != nil {
+		t.Fatalf("Failed to create node: %v", err)
+	}
+	defer wp.Delete()
+
+	expectedErr := errors.New("worker error")
+	wp.SetProcessFunc(func(input []byte) ([]byte, error) {
+		return nil, expectedErr
+	})
+
+	_, err := wp.Process([]byte("test"))
+	if err != expectedErr {
+		t.Fatalf("Expected error %v, got %v", expectedErr, err)
+	}
+}

--- a/node/worker_pool_node.go
+++ b/node/worker_pool_node.go
@@ -1,0 +1,156 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// WorkerPoolNode uses a pool of concurrent goroutines to process incoming
+// requests using a channel-based task queue.
+type WorkerPoolNode struct {
+	*BaseNode
+	numWorkers  int
+	taskQueue   chan *workerTask
+	ctx         context.Context
+	cancel      context.CancelFunc
+	wg          sync.WaitGroup
+	shutdownOne sync.Once
+	workerFunc  func([]byte) ([]byte, error)
+}
+
+type workerTask struct {
+	input      []byte
+	resultChan chan workerResult
+}
+
+type workerResult struct {
+	output []byte
+	err    error
+}
+
+// NewWorkerPoolNode creates a new WorkerPoolNode with the specified number of workers.
+func NewWorkerPoolNode(id string, numWorkers int) *WorkerPoolNode {
+	if numWorkers <= 0 {
+		numWorkers = 1
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	wpNode := &WorkerPoolNode{
+		BaseNode:   NewBaseNode(id),
+		numWorkers: numWorkers,
+		taskQueue:  make(chan *workerTask, numWorkers*2), // buffer to allow some queuing
+		ctx:        ctx,
+		cancel:     cancel,
+		workerFunc: func(input []byte) ([]byte, error) {
+			return input, nil
+		},
+	}
+
+	// We overwrite the Process function to handle the queuing logic.
+	// We do NOT want the default BaseNode process function logic since this node
+	// works differently (it dispatches to the pool).
+	wpNode.BaseNode.SetProcessFunc(wpNode.dispatchProcess)
+
+	return wpNode
+}
+
+// SetProcessFunc sets the function that the workers will execute.
+// We override BaseNode's SetProcessFunc because we need to store the function
+// to be executed *by the workers*, not by the dispatch mechanism itself.
+func (wp *WorkerPoolNode) SetProcessFunc(processFunc func([]byte) ([]byte, error)) {
+	wp.BaseNode.mutex.Lock()
+	defer wp.BaseNode.mutex.Unlock()
+	wp.workerFunc = processFunc
+}
+
+func (wp *WorkerPoolNode) dispatchProcess(input []byte) ([]byte, error) {
+	// Fast fail if shutting down
+	select {
+	case <-wp.ctx.Done():
+		return nil, errors.New("worker pool is shutting down")
+	default:
+	}
+
+	resChan := make(chan workerResult, 1)
+
+	// Clone input to prevent data races
+	inputCopy := make([]byte, len(input))
+	copy(inputCopy, input)
+
+	task := &workerTask{
+		input:      inputCopy,
+		resultChan: resChan,
+	}
+
+	select {
+	case wp.taskQueue <- task:
+		// Task enqueued
+	case <-wp.ctx.Done():
+		return nil, errors.New("worker pool is shutting down")
+	}
+
+	select {
+	case res := <-resChan:
+		return res.output, res.err
+	case <-wp.ctx.Done():
+		return nil, errors.New("worker pool is shutting down")
+	}
+}
+
+// Create initializes the worker pool and starts the worker goroutines.
+func (wp *WorkerPoolNode) Create() error {
+	if err := wp.BaseNode.Create(); err != nil {
+		return err
+	}
+
+	for i := 0; i < wp.numWorkers; i++ {
+		wp.wg.Add(1)
+		go wp.workerLoop()
+	}
+
+	return nil
+}
+
+func (wp *WorkerPoolNode) workerLoop() {
+	defer wp.wg.Done()
+	for {
+		select {
+		case <-wp.ctx.Done():
+			return
+		case task := <-wp.taskQueue:
+			wp.BaseNode.mutex.RLock()
+			wFunc := wp.workerFunc
+			wp.BaseNode.mutex.RUnlock()
+
+			out, err := wFunc(task.input)
+			task.resultChan <- workerResult{output: out, err: err}
+		}
+	}
+}
+
+// Delete cleanly shuts down the worker pool.
+func (wp *WorkerPoolNode) Delete() error {
+	wp.shutdownOne.Do(func() {
+		// Signal shutdown to all workers
+		wp.cancel()
+
+		// Wait for active workers to finish current task and exit loop
+		wp.wg.Wait()
+
+		// Drain the channel safely without closing it
+		// to avoid "send on closed channel" panic from concurrent active dispatches.
+	drainLoop:
+		for {
+			select {
+			case t := <-wp.taskQueue:
+				// Notify queued tasks they were cancelled during shutdown
+				t.resultChan <- workerResult{err: errors.New("worker pool shut down before task could be processed")}
+			default:
+				break drainLoop
+			}
+		}
+	})
+
+	return wp.BaseNode.Delete()
+}


### PR DESCRIPTION
💡 What: Adds `WorkerPoolNode` for managing a pool of concurrent worker goroutines with a task queue, `FanOutNode` for scatter-gather patterns with concurrent mapping and timeouts, `MetricsMiddleware` to track node execution metrics, and `RateLimiterMiddleware` using a token bucket approach.
🎯 Why: Increases flexibility of node processing and expands the repertoire of tools available for building complex networked applications and data pipelines. Rate limiting and metrics enhance operational visibility and stability.
📊 Impact: Expands `node` package capabilities. Middlewares augment existing nodes seamlessly.
🔬 Measurement: Covered by comprehensive unit tests running in `go test ./...` covering node functionalities, middleware processing, edge cases, concurrent state management and shutdown paths.

---
*PR created automatically by Jules for task [921903409957386884](https://jules.google.com/task/921903409957386884) started by @lhemerly*